### PR TITLE
소셜 로그인 관련 기능 및 인증 구현

### DIFF
--- a/src/main/java/org/unisphere/unisphere/annotation/LoginMemberInfo.java
+++ b/src/main/java/org/unisphere/unisphere/annotation/LoginMemberInfo.java
@@ -1,0 +1,17 @@
+package org.unisphere.unisphere.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+@Parameter(hidden = true)
+public @interface LoginMemberInfo {
+
+}
+

--- a/src/main/java/org/unisphere/unisphere/article/domain/Article.java
+++ b/src/main/java/org/unisphere/unisphere/article/domain/Article.java
@@ -53,6 +53,7 @@ public class Article {
 	@Column
 	private LocalDateTime approvedAt;
 
+	@ToString.Exclude
 	@OneToMany(mappedBy = "article", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<InterestedArticle> interestedArticles = new ArrayList<>();
 }

--- a/src/main/java/org/unisphere/unisphere/auth/controller/AuthController.java
+++ b/src/main/java/org/unisphere/unisphere/auth/controller/AuthController.java
@@ -1,14 +1,37 @@
 package org.unisphere.unisphere.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.unisphere.unisphere.annotation.LoginMemberInfo;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+import org.unisphere.unisphere.auth.dto.MemberSessionDto;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/api/v1/auth")
+@Tag(name = "인증", description = "인증 관련 API")
 public class AuthController {
 
+	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 요청합니다. 회원과 관련된 모든 정보가 삭제되며, 소셜 인증 기관에 revoke 요청을 수행합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+	})
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping(value = "/unregister")
+	@Secured(MemberRole.S_USER)
+	// TODO: 추후 탈퇴 로직 구현 필요
+	public void unregister(@LoginMemberInfo MemberSessionDto memberSessionDto) {
+		log.info("Called unregister member: {}", memberSessionDto);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/auth/domain/CookieManager.java
+++ b/src/main/java/org/unisphere/unisphere/auth/domain/CookieManager.java
@@ -1,0 +1,35 @@
+package org.unisphere.unisphere.auth.domain;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.unisphere.unisphere.config.CookieConfig;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+/*
+  쿠키 관리를 담당하는 클래스
+ */
+public class CookieManager {
+
+	private final CookieConfig cookieConfig;
+
+	/**
+	 * 쿠키를 생성하여 HttpServletResponse 객체에 추가한다.
+	 *
+	 * @param res   클라이언트에게 보낼 응답을 나타내는 HttpServletResponse 객체
+	 * @param token 쿠키에 저장될 토큰 값
+	 */
+	public void createCookie(HttpServletResponse res, String token) {
+		log.info("Called setCookie path");
+		Cookie cookie = new Cookie(cookieConfig.getName(), token);
+		cookie.setPath(cookieConfig.getPath());
+		cookie.setMaxAge(cookieConfig.getMaxAge());
+		cookie.setHttpOnly(cookieConfig.isHttpOnly());
+		cookie.setDomain(cookieConfig.getDomain());
+		res.addCookie(cookie);
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/domain/MemberAuthenticationToken.java
+++ b/src/main/java/org/unisphere/unisphere/auth/domain/MemberAuthenticationToken.java
@@ -1,0 +1,28 @@
+package org.unisphere.unisphere.auth.domain;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class MemberAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+
+	public MemberAuthenticationToken(
+			Object principal,
+			Collection<? extends GrantedAuthority> authorities
+	) {
+		super(authorities);
+		this.principal = principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return principal;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/domain/MemberRole.java
+++ b/src/main/java/org/unisphere/unisphere/auth/domain/MemberRole.java
@@ -1,5 +1,7 @@
 package org.unisphere.unisphere.auth.domain;
 
 public enum MemberRole {
-	COMMON, ADMIN
+	MEMBER, ADMIN;
+	public static final String S_ADMIN = "ROLE_ADMIN";
+	public static final String S_MEMBER = "ROLE_MEMBER";
 }

--- a/src/main/java/org/unisphere/unisphere/auth/domain/MemberRole.java
+++ b/src/main/java/org/unisphere/unisphere/auth/domain/MemberRole.java
@@ -3,5 +3,5 @@ package org.unisphere.unisphere.auth.domain;
 public enum MemberRole {
 	MEMBER, ADMIN;
 	public static final String S_ADMIN = "ROLE_ADMIN";
-	public static final String S_MEMBER = "ROLE_MEMBER";
+	public static final String S_USER = "ROLE_USER";
 }

--- a/src/main/java/org/unisphere/unisphere/auth/dto/MemberSessionDto.java
+++ b/src/main/java/org/unisphere/unisphere/auth/dto/MemberSessionDto.java
@@ -1,0 +1,21 @@
+package org.unisphere.unisphere.auth.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@ToString
+/*
+  로그인한 회원의 정보를 담는 클래스
+ */
+public class MemberSessionDto {
+
+	private final Long memberId;
+	private final List<MemberRole> roles;
+}

--- a/src/main/java/org/unisphere/unisphere/auth/filter/MemberAuthenticationFilter.java
+++ b/src/main/java/org/unisphere/unisphere/auth/filter/MemberAuthenticationFilter.java
@@ -1,0 +1,97 @@
+package org.unisphere.unisphere.auth.filter;
+
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.Transient;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.unisphere.unisphere.auth.domain.MemberAuthenticationToken;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+import org.unisphere.unisphere.auth.dto.MemberSessionDto;
+import org.unisphere.unisphere.auth.jwt.JwtConfig;
+import org.unisphere.unisphere.exception.JwtAuthenticationTokenException;
+
+@Transient
+@Slf4j
+@RequiredArgsConstructor
+/*
+ * JWT 토큰을 이용한 인증을 위한 커스텀 인증 필터
+ */
+public class MemberAuthenticationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+			HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		SecurityContext context = SecurityContextHolder.getContext();
+		Authentication authentication = context.getAuthentication();
+
+		if (authentication == null) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+			return;
+		}
+		try {
+			if (authentication instanceof JwtAuthenticationToken) {
+				JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+				MemberAuthenticationToken token = convert(jwtAuthenticationToken);
+				context.setAuthentication(token);
+				SecurityContextHolder.clearContext();
+				SecurityContextHolder.setContext(context);
+			}
+		} catch (JwtAuthenticationTokenException e) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+			return;
+		}
+		doFilter(request, response, filterChain);
+	}
+
+	/**
+	 * JwtAuthenticationToken을 우리 시스템의 커스텀 MemberSessionAuthenticationToken으로 변환한다.
+	 *
+	 * @param token JwtAuthenticationToken 인증 토큰
+	 * @return 변환된 커스텀 인증 토큰
+	 */
+	private MemberAuthenticationToken convert(JwtAuthenticationToken token) {
+		Object target = token.getPrincipal();
+		if (target instanceof Jwt) {
+			Jwt jwt = (Jwt) target;
+			MemberSessionDto principal = convertPrincipal(jwt);
+			MemberAuthenticationToken ret = new MemberAuthenticationToken(principal,
+					token.getAuthorities());
+			ret.setAuthenticated(true);
+			log.info("convert token principal: {}, authorities: {}", ret.getPrincipal(),
+					token.getAuthorities());
+			return ret;
+		}
+		throw new JwtAuthenticationTokenException("Jwt 토큰이 아닙니다.");
+	}
+
+	/**
+	 * Jwt Principal 정보를 토대로 회원 인증 정보 DTO 객체를 생성한다.
+	 *
+	 * @param jwt Jwt Principal 정보
+	 * @return 회원 인증 정보 DTO 객체
+	 */
+	private MemberSessionDto convertPrincipal(Jwt jwt) {
+		Long memberId = jwt.getClaim(JwtConfig.MEMBER_ID);
+		List<MemberRole> roles = jwt.getClaim(JwtConfig.ROLES);
+		log.debug("memberId: {}, roles: {}", memberId, roles);
+		if (memberId == null || roles == null) {
+			throw new JwtAuthenticationTokenException("Jwt에 필요한 정보가 없습니다.");
+		}
+		return MemberSessionDto.builder()
+				.memberId(memberId)
+				.roles(roles)
+				.build();
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtAuthenticationConfig.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtAuthenticationConfig.java
@@ -1,0 +1,71 @@
+package org.unisphere.unisphere.auth.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtAuthenticationConfig {
+
+	private final JwtDecoder jwtDecoder;
+	private final JwtAuthenticationConverter jwtAuthenticationConverter;
+
+	@Bean
+	/*
+	  JwtAuthenticationManager를 Bean으로 등록한다.
+	  JwtAuthenticationProvider를 이용하여 인증을 수행한다.
+	 */
+	public AuthenticationManager jwtAuthenticationManager() {
+		return (Authentication authentication) -> {
+			AuthenticationProvider authenticationProvider = jwtAuthenticationProvider();
+			if (authenticationProvider.supports(authentication.getClass())) {
+				return authenticationProvider.authenticate(authentication);
+			}
+			throw new AuthenticationServiceException(
+					"Unsupported authentication type: " + authentication.getClass().getName());
+		};
+	}
+
+	@Bean
+	/*
+	  JwtAuthenticationProvider를 Bean으로 등록한다.
+	  BearerTokenAuthenticationToken을 Jwt로 변환한다.
+	 */
+	public AuthenticationProvider jwtAuthenticationProvider() {
+		return new AuthenticationProvider() {
+			@Override
+			public Authentication authenticate(Authentication authentication)
+					throws AuthenticationException {
+				BearerTokenAuthenticationToken token = (BearerTokenAuthenticationToken) authentication;
+				Jwt jwt = getJwt(token);
+				return jwtAuthenticationConverter.convert(jwt);
+			}
+
+			@Override
+			public boolean supports(Class<?> authentication) {
+				return authentication.equals(BearerTokenAuthenticationToken.class);
+			}
+
+			private Jwt getJwt(BearerTokenAuthenticationToken token) {
+				try {
+					return jwtDecoder.decode(token.getToken());
+				} catch (JwtException e) {
+					throw new InvalidBearerTokenException("jwt 관련 오류", e);
+				} catch (RuntimeException e) {
+					throw new InvalidBearerTokenException("jwt 파싱 관련 오류", e);
+				}
+			}
+		};
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtAuthenticationConverter.java
@@ -1,0 +1,47 @@
+package org.unisphere.unisphere.auth.jwt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticationToken> {
+
+	private static final String ROLE_PREFIX = "ROLE_";
+	private static final String SCOPE_PREFIX = "SCOPE_";
+
+	@Override
+	/*
+	  Jwt를 JwtAuthenticationToken으로 변환한다.
+	  @param jwt 변환할 Jwt
+	 * @return JwtAuthenticationToken 변환된 JwtAuthenticationToken
+	 */
+	public JwtAuthenticationToken convert(Jwt jwt) {
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		if (jwt.hasClaim(JwtConfig.ROLES)) {
+			authorities.addAll(
+					jwt.getClaimAsStringList(JwtConfig.ROLES)
+							.stream()
+							.map(role -> ROLE_PREFIX + role)
+							.map(SimpleGrantedAuthority::new)
+							.collect(Collectors.toList())
+			);
+		}
+		if (jwt.hasClaim(JwtConfig.SCOPES)) {
+			authorities.addAll(jwt.getClaimAsStringList(JwtConfig.SCOPES).stream()
+					.map(scope -> SCOPE_PREFIX + scope)
+					.map(SimpleGrantedAuthority::new)
+					.collect(Collectors.toList())
+			);
+		}
+		return new JwtAuthenticationToken(jwt, authorities, jwt.getSubject());
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtAuthenticationConverter.java
@@ -30,14 +30,12 @@ public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticat
 			authorities.addAll(
 					jwt.getClaimAsStringList(JwtConfig.ROLES)
 							.stream()
-							.map(role -> ROLE_PREFIX + role)
 							.map(SimpleGrantedAuthority::new)
 							.collect(Collectors.toList())
 			);
 		}
 		if (jwt.hasClaim(JwtConfig.SCOPES)) {
 			authorities.addAll(jwt.getClaimAsStringList(JwtConfig.SCOPES).stream()
-					.map(scope -> SCOPE_PREFIX + scope)
 					.map(SimpleGrantedAuthority::new)
 					.collect(Collectors.toList())
 			);

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtCodecConfig.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtCodecConfig.java
@@ -1,0 +1,39 @@
+package org.unisphere.unisphere.auth.jwt;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+@Configuration
+public class JwtCodecConfig {
+
+	private final static MacAlgorithm algorithm = MacAlgorithm.HS256;
+	private final SecretKey key;
+
+	public JwtCodecConfig(
+			@Value("${spring.jwt.key}") String secretKey
+	) {
+		this.key = new SecretKeySpec(secretKey.getBytes(), algorithm.getName());
+	}
+
+	@Bean
+	public JwtDecoder jwtDecoder() {
+		return NimbusJwtDecoder
+				.withSecretKey(key)
+				.macAlgorithm(algorithm)
+				.build();
+	}
+
+	@Bean
+	public JwtEncoder jwtEncoder() {
+		return new NimbusJwtEncoder(new ImmutableSecret<>(key));
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtConfig.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtConfig.java
@@ -1,0 +1,20 @@
+package org.unisphere.unisphere.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class JwtConfig {
+
+	public static final String ROLES = "roles";
+	public static final String SCOPES = "scopes";
+	public static final String MEMBER_ID = "memberId";
+
+	@Value("${unisphere.jwt.common-token-expire-time}")
+	private long commonTokenExpireTime;
+
+	@Value("${unisphere.jwt.refresh-token-expire-time}")
+	private long refreshTokenExpireTime;
+}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtExceptionHandler.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtExceptionHandler.java
@@ -1,0 +1,31 @@
+package org.unisphere.unisphere.auth.jwt;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+@Configuration
+public class JwtExceptionHandler {
+
+	@Bean
+	public AuthenticationEntryPoint jwtAuthenticationEntryPoint() {
+		return (HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) -> {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+					"인증되지 않은 요청입니다."
+			);
+		};
+	}
+
+	@Bean
+	public AccessDeniedHandler jwtAccessDeniedHandler() {
+		return (HttpServletRequest request, HttpServletResponse response, org.springframework.security.access.AccessDeniedException accessDeniedException) -> {
+			response.sendError(HttpServletResponse.SC_FORBIDDEN,
+					"권한이 없는 요청입니다."
+			);
+		};
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtTokenProvider.java
@@ -38,7 +38,7 @@ public class JwtTokenProvider {
 				.issuedAt(now)
 				.expiresAt(now.plusSeconds(jwtConfig.getCommonTokenExpireTime()))
 				.claim(JwtConfig.MEMBER_ID, id)
-				.claim(JwtConfig.ROLES, List.of(MemberRole.S_MEMBER))
+				.claim(JwtConfig.ROLES, List.of(MemberRole.S_USER))
 				.build();
 		return jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
 	}

--- a/src/main/java/org/unisphere/unisphere/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/unisphere/unisphere/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,46 @@
+package org.unisphere.unisphere.auth.jwt;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Component;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+
+@Component
+@RequiredArgsConstructor
+/*
+  JWT 토큰 생성을 위한 클래스
+ */
+public class JwtTokenProvider {
+
+	private final JwtEncoder jwtEncoder;
+	private final JwtConfig jwtConfig;
+
+	/**
+	 * 주어진 ID를 가진 회원의 Common Access JWT Token을 생성한다.
+	 *
+	 * @param id 회원의 ID
+	 * @return 생성된 JWT Token
+	 */
+	public Jwt createCommonAccessToken(Long id) {
+		Instant now = Instant.now();
+		JwsHeader header = JwsHeader
+				.with(MacAlgorithm.HS256)
+				.build();
+
+		JwtClaimsSet claims = JwtClaimsSet.builder()
+				.issuedAt(now)
+				.expiresAt(now.plusSeconds(jwtConfig.getCommonTokenExpireTime()))
+				.claim(JwtConfig.MEMBER_ID, id)
+				.claim(JwtConfig.ROLES, List.of(MemberRole.S_MEMBER))
+				.build();
+		return jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
+	}
+}
+

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/OauthHandler.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/OauthHandler.java
@@ -43,10 +43,12 @@ public class OauthHandler {
 			cookieManager.createCookie(
 					response, jwtToken
 			);
-			response.sendRedirect(
-					clientConfig.getClientUrl() + clientConfig.getClientCallbackUrl()
-							+ "?isFirstLogin="
-							+ member.isFirstLogin());
+
+			String redirectUrl = clientConfig.getClientUrl() + clientConfig.getClientCallbackUrl();
+			if (member.isFirstLogin()) {
+				redirectUrl += "?isFirstLogin=true";
+			}
+			response.sendRedirect(redirectUrl);
 		};
 	}
 

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/OauthHandler.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/OauthHandler.java
@@ -9,6 +9,8 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.unisphere.unisphere.auth.domain.CookieManager;
+import org.unisphere.unisphere.auth.jwt.JwtTokenProvider;
 import org.unisphere.unisphere.auth.oauth.extractor.OauthAttributeExtractor;
 import org.unisphere.unisphere.auth.service.AuthService;
 import org.unisphere.unisphere.config.ClientConfig;
@@ -21,6 +23,9 @@ public class OauthHandler {
 
 	private final AuthService authService;
 	private final ClientConfig clientConfig;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final CookieManager cookieManager;
+
 
 	@Bean
 	public AuthenticationSuccessHandler oauthAuthenticationSuccessHandler() {
@@ -33,12 +38,11 @@ public class OauthHandler {
 			);
 			Member member = authService.createAndFindOauthSocialMember(extractor);
 			log.info("Member Login Success: {}", member);
-//          TODO: JWT 토큰 발행 로직 추가
-//			String jwtToken = jwtTokenProvider.createCommonAccessToken(member.getId())
-//					.getTokenValue();
-//			cookieManager.createCookie(
-//					response, jwtToken
-//			);
+			String jwtToken = jwtTokenProvider.createCommonAccessToken(member.getId())
+					.getTokenValue();
+			cookieManager.createCookie(
+					response, jwtToken
+			);
 			response.sendRedirect(
 					clientConfig.getClientUrl() + clientConfig.getClientCallbackUrl()
 							+ "?isFirstLogin="

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/OauthHandler.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/OauthHandler.java
@@ -1,0 +1,56 @@
+package org.unisphere.unisphere.auth.oauth;
+
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.unisphere.unisphere.auth.oauth.extractor.OauthAttributeExtractor;
+import org.unisphere.unisphere.auth.service.AuthService;
+import org.unisphere.unisphere.config.ClientConfig;
+import org.unisphere.unisphere.member.domain.Member;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class OauthHandler {
+
+	private final AuthService authService;
+	private final ClientConfig clientConfig;
+
+	@Bean
+	public AuthenticationSuccessHandler oauthAuthenticationSuccessHandler() {
+		return (request, response, authentication) -> {
+			DefaultOAuth2User auth2User = (DefaultOAuth2User) authentication.getPrincipal();
+			OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+			String providerName = token.getAuthorizedClientRegistrationId();
+			OauthAttributeExtractor extractor = OauthAttributeExtractor.create(
+					auth2User, providerName
+			);
+			Member member = authService.createAndFindOauthSocialMember(extractor);
+			log.info("Member Login Success: {}", member);
+//          TODO: JWT 토큰 발행 로직 추가
+//			String jwtToken = jwtTokenProvider.createCommonAccessToken(member.getId())
+//					.getTokenValue();
+//			cookieManager.createCookie(
+//					response, jwtToken
+//			);
+			response.sendRedirect(
+					clientConfig.getClientUrl() + clientConfig.getClientCallbackUrl()
+							+ "?isFirstLogin="
+							+ member.isFirstLogin());
+		};
+	}
+
+	@Bean
+	public AuthenticationFailureHandler oauthAuthenticationFailureHandler() {
+		return (request, response, exception) -> {
+			log.error("OAuth2 Login Failure", exception);
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		};
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/OauthAttributeExtractor.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/OauthAttributeExtractor.java
@@ -1,0 +1,50 @@
+package org.unisphere.unisphere.auth.oauth.extractor;
+
+import java.util.Map;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.unisphere.unisphere.auth.domain.OauthType;
+import org.unisphere.unisphere.auth.oauth.extractor.google.GoogleOauthAttributeExtractor;
+import org.unisphere.unisphere.auth.oauth.extractor.kakao.KakaoOauthAttributeExtractor;
+import org.unisphere.unisphere.auth.oauth.extractor.naver.NaverOauthAttributeExtractor;
+
+/**
+ * // @formatter:off
+ * Oauth2User로부터 속성을 추출하는 메서드를 정의하는 인터페이스 Oauth 유저 정보를 추출하여 우리 시스템에 맞도록 변환하는 역할을 한다.
+ * 소셜 인증 기관이 추가되면이 인터페이스를 구현하여 Oauth2User로부터 속성을 추출하는 메서드를 정의해야 한다.
+ * // @formatter:on
+ */
+public interface OauthAttributeExtractor {
+
+	String getEmail();
+
+	String getNickname();
+
+	OauthType getOauthType();
+
+	String getOauthId();
+
+	static OauthAttributeExtractor create(OAuth2User auth2User, String providerName) {
+		switch (providerName) {
+			case "google":
+				return new GoogleOauthAttributeExtractor(auth2User);
+			case "kakao":
+				return new KakaoOauthAttributeExtractor(auth2User);
+			case "naver":
+				return new NaverOauthAttributeExtractor(auth2User);
+			default:
+				throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
+		}
+	}
+
+	static String getNestedAttribute(OAuth2User user, String... keys) {
+		Object value = user.getAttributes();
+		for (String key : keys) {
+			if (!(value instanceof Map)) {
+				return null;
+			}
+			value = ((Map<?, ?>) value).get(key);
+		}
+		return value instanceof String ? (String) value : null;
+	}
+}
+

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/google/GoogleOauthAttributeExtractor.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/google/GoogleOauthAttributeExtractor.java
@@ -1,0 +1,37 @@
+package org.unisphere.unisphere.auth.oauth.extractor.google;
+
+import lombok.ToString;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.unisphere.unisphere.auth.domain.OauthType;
+import org.unisphere.unisphere.auth.oauth.extractor.OauthAttributeExtractor;
+
+@ToString
+public class GoogleOauthAttributeExtractor implements OauthAttributeExtractor {
+
+	private final OAuth2User auth2User;
+
+	public GoogleOauthAttributeExtractor(OAuth2User auth2User) {
+		this.auth2User = auth2User;
+	}
+
+	@Override
+	public String getEmail() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "email");
+	}
+
+	@Override
+	public String getNickname() {
+		System.out.println("auth2User = " + auth2User);
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "name");
+	}
+
+	@Override
+	public OauthType getOauthType() {
+		return OauthType.GOOGLE;
+	}
+
+	@Override
+	public String getOauthId() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "sub");
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/kakao/KakaoOauthAttributeExtractor.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/kakao/KakaoOauthAttributeExtractor.java
@@ -1,0 +1,39 @@
+package org.unisphere.unisphere.auth.oauth.extractor.kakao;
+
+
+import java.util.Objects;
+import lombok.ToString;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.unisphere.unisphere.auth.domain.OauthType;
+import org.unisphere.unisphere.auth.oauth.extractor.OauthAttributeExtractor;
+
+@ToString
+public class KakaoOauthAttributeExtractor implements OauthAttributeExtractor {
+
+	private final OAuth2User auth2User;
+
+	public KakaoOauthAttributeExtractor(OAuth2User auth2User) {
+		this.auth2User = auth2User;
+	}
+
+	@Override
+	public String getEmail() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "kakao_account",
+				"email");
+	}
+
+	@Override
+	public String getNickname() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "properties", "nickname");
+	}
+
+	@Override
+	public OauthType getOauthType() {
+		return OauthType.KAKAO;
+	}
+
+	@Override
+	public String getOauthId() {
+		return Objects.requireNonNull(auth2User.getAttribute("id")).toString();
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/naver/NaverOauthAttributeExtractor.java
+++ b/src/main/java/org/unisphere/unisphere/auth/oauth/extractor/naver/NaverOauthAttributeExtractor.java
@@ -1,0 +1,36 @@
+package org.unisphere.unisphere.auth.oauth.extractor.naver;
+
+import lombok.ToString;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.unisphere.unisphere.auth.domain.OauthType;
+import org.unisphere.unisphere.auth.oauth.extractor.OauthAttributeExtractor;
+
+@ToString
+public class NaverOauthAttributeExtractor implements OauthAttributeExtractor {
+
+	private final OAuth2User auth2User;
+
+	public NaverOauthAttributeExtractor(OAuth2User auth2User) {
+		this.auth2User = auth2User;
+	}
+
+	@Override
+	public String getEmail() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "response", "email");
+	}
+
+	@Override
+	public String getNickname() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "response", "nickname");
+	}
+
+	@Override
+	public OauthType getOauthType() {
+		return OauthType.NAVER;
+	}
+
+	@Override
+	public String getOauthId() {
+		return OauthAttributeExtractor.getNestedAttribute(auth2User, "response", "id");
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/auth/service/AuthService.java
+++ b/src/main/java/org/unisphere/unisphere/auth/service/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
 										extractor.getEmail(),
 										extractor.getNickname() + UUID.randomUUID(),
 										LocalDateTime.now(),
-										MemberRole.COMMON,
+										MemberRole.MEMBER,
 										extractor.getOauthId(),
 										extractor.getOauthType()
 								)

--- a/src/main/java/org/unisphere/unisphere/auth/service/AuthService.java
+++ b/src/main/java/org/unisphere/unisphere/auth/service/AuthService.java
@@ -1,0 +1,38 @@
+package org.unisphere.unisphere.auth.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+import org.unisphere.unisphere.auth.oauth.extractor.OauthAttributeExtractor;
+import org.unisphere.unisphere.member.domain.Member;
+import org.unisphere.unisphere.member.infrastructure.MemberRepository;
+
+@Service
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final MemberRepository memberRepository;
+
+	public Member createAndFindOauthSocialMember(OauthAttributeExtractor extractor) {
+		log.info("Called createAndFindOauthSocialMember: extractor = {}", extractor);
+		return memberRepository.findByEmail(extractor.getEmail())
+				.orElseGet(() ->
+						memberRepository.save(
+								Member.createSocialMember(
+										extractor.getEmail(),
+										extractor.getNickname() + UUID.randomUUID(),
+										LocalDateTime.now(),
+										MemberRole.COMMON,
+										extractor.getOauthId(),
+										extractor.getOauthType()
+								)
+						)
+				);
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/config/CookieConfig.java
+++ b/src/main/java/org/unisphere/unisphere/config/CookieConfig.java
@@ -1,0 +1,31 @@
+package org.unisphere.unisphere.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class CookieConfig {
+
+	@Value("${unisphere.cookie.domain}")
+	private String domain;
+
+	@Value("${unisphere.cookie.name}")
+	private String name;
+
+	@Value("${unisphere.cookie.path}")
+	private String path;
+
+	@Value("${unisphere.cookie.max-age}")
+	private int maxAge;
+
+	@Value("${unisphere.cookie.http-only}")
+	private boolean httpOnly;
+
+	@Value("${unisphere.cookie.secure}")
+	private boolean secure;
+
+	@Value("${unisphere.cookie.same-site}")
+	private String sameSite;
+}

--- a/src/main/java/org/unisphere/unisphere/config/SecurityConfig.java
+++ b/src/main/java/org/unisphere/unisphere/config/SecurityConfig.java
@@ -9,7 +9,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -20,6 +19,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.unisphere.unisphere.auth.filter.MemberAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -40,8 +40,7 @@ public class SecurityConfig {
 //		@formatter:off
 		httpSecurity
 				.formLogin().disable()
-//				TODO: 커스텀 인증 필터를 추가 후 주석 해제
-//				.addFilterAfter(new MemberSessionAuthenticationFilter(), BearerTokenAuthenticationFilter.class)
+				.addFilterAfter(new MemberAuthenticationFilter(), BearerTokenAuthenticationFilter.class)
 				.cors()
 					.configurationSource(corsConfigurationSource())
 				.and()

--- a/src/main/java/org/unisphere/unisphere/config/SecurityConfig.java
+++ b/src/main/java/org/unisphere/unisphere/config/SecurityConfig.java
@@ -4,13 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -22,15 +23,16 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class SecurityConfig {
 
 	private final ServerConfig serverConfig;
 	private final ClientConfig clientConfig;
-//	private final AuthenticationManager jwtAuthenticationManager;
+	//	private final AuthenticationManager jwtAuthenticationManager;
 //	private final AccessDeniedHandler jwtAccessDeniedHandler;
 //	private final AuthenticationEntryPoint jwtAuthenticationEntryPoint;
-//	private final AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
-//	private final AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
+	private final AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
+	private final AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -57,19 +59,19 @@ public class SecurityConfig {
 //					.accessDeniedHandler(jwtAccessDeniedHandler)
 //					.authenticationEntryPoint(jwtAuthenticationEntryPoint)
 //				.and()
-//				.oauth2Login()
+				.oauth2Login()
 //		        TODO: OAuth2 성공/실패 핸들러를 추가 후 주석 해제
 //				TODO: OAuth2 로그인/콜백 엔드포인트를 추가 후 주석 해제
 
-//					.successHandler(oauth2AuthenticationSuccessHandler)
-//					.failureHandler(oauth2AuthenticationFailureHandler)
-//					.userInfoEndpoint()
-//					.and()
-//					.authorizationEndpoint()
-//						.baseUri(serverConfig.getOauth2LoginEndpoint())
-//					.and()
-//					.redirectionEndpoint()
-//						.baseUri(serverConfig.getOauth2CallbackEndpoint())
+					.successHandler(oauth2AuthenticationSuccessHandler)
+					.failureHandler(oauth2AuthenticationFailureHandler)
+					.userInfoEndpoint()
+					.and()
+					.authorizationEndpoint()
+						.baseUri(serverConfig.getOauth2LoginEndpoint())
+					.and()
+					.redirectionEndpoint()
+						.baseUri(serverConfig.getOauth2CallbackEndpoint())
 		;
 		return httpSecurity.build();
 //		@formatter:on

--- a/src/main/java/org/unisphere/unisphere/config/SecurityConfig.java
+++ b/src/main/java/org/unisphere/unisphere/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -28,9 +29,9 @@ public class SecurityConfig {
 
 	private final ServerConfig serverConfig;
 	private final ClientConfig clientConfig;
-	//	private final AuthenticationManager jwtAuthenticationManager;
-//	private final AccessDeniedHandler jwtAccessDeniedHandler;
-//	private final AuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final AuthenticationManager jwtAuthenticationManager;
+	private final AccessDeniedHandler jwtAccessDeniedHandler;
+	private final AuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
 	private final AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
 
@@ -48,21 +49,15 @@ public class SecurityConfig {
 				.sessionManagement()
 					.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				.and()
-//				TODO: JwtAuthentiManager를 추가 후 주석 해제
-//				TODO: Jwt 성공/실패 핸들러를 추가 후 주석 해제
-
-//				.oauth2ResourceServer()
-//					.bearerTokenResolver(new DefaultBearerTokenResolver())
-//					.jwt()
-//						.authenticationManager(jwtAuthenticationManager)
-//					.and()
-//					.accessDeniedHandler(jwtAccessDeniedHandler)
-//					.authenticationEntryPoint(jwtAuthenticationEntryPoint)
-//				.and()
+				.oauth2ResourceServer()
+					.bearerTokenResolver(new DefaultBearerTokenResolver())
+					.jwt()
+						.authenticationManager(jwtAuthenticationManager)
+					.and()
+					.accessDeniedHandler(jwtAccessDeniedHandler)
+					.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+				.and()
 				.oauth2Login()
-//		        TODO: OAuth2 성공/실패 핸들러를 추가 후 주석 해제
-//				TODO: OAuth2 로그인/콜백 엔드포인트를 추가 후 주석 해제
-
 					.successHandler(oauth2AuthenticationSuccessHandler)
 					.failureHandler(oauth2AuthenticationFailureHandler)
 					.userInfoEndpoint()

--- a/src/main/java/org/unisphere/unisphere/config/SwaggerConfig.java
+++ b/src/main/java/org/unisphere/unisphere/config/SwaggerConfig.java
@@ -14,23 +14,21 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @OpenAPIDefinition(
-		info = @Info(title = "Jungko-Server API", version = "v1")
-//		TODO: JWT 인증 구현 후 주석 해제
-//		security = @SecurityRequirement(name = "bearerAuth")
+		info = @Info(title = "Jungko-Server API", version = "v1"),
+		security = @SecurityRequirement(name = "bearerAuth")
 )
-//@SecurityScheme(
-//		name = "bearerAuth",
-//		type = SecuritySchemeType.HTTP,
-//		scheme = "bearer"
-//)
+@SecurityScheme(
+		name = "bearerAuth",
+		type = SecuritySchemeType.HTTP,
+		scheme = "bearer"
+)
 public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI getOpenAPI() {
 		return new OpenAPI().components(new Components()
-//      TODO: JWT 인증 구현 후 주석 해제
-//				.addHeaders("Authorization",
-//						new Header().description("Auth header").schema(new StringSchema()))
+				.addHeaders("Authorization",
+						new Header().description("Auth header").schema(new StringSchema()))
 		);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/exception/JwtAuthenticationTokenException.java
+++ b/src/main/java/org/unisphere/unisphere/exception/JwtAuthenticationTokenException.java
@@ -1,0 +1,8 @@
+package org.unisphere.unisphere.exception;
+
+public class JwtAuthenticationTokenException extends RuntimeException {
+
+	public JwtAuthenticationTokenException(String s) {
+		super(s);
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -53,6 +53,7 @@ public class Group {
 	@Column
 	private LocalDateTime approvedAt;
 
+	@ToString.Exclude
 	@OneToMany(mappedBy = "group", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<GroupRegistration> groupRegistrations = new ArrayList<>();
 }

--- a/src/main/java/org/unisphere/unisphere/member/domain/Member.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/Member.java
@@ -14,12 +14,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.unisphere.unisphere.article.domain.InterestedArticle;
 import org.unisphere.unisphere.auth.domain.MemberRole;
+import org.unisphere.unisphere.auth.domain.OauthType;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
 
 @Entity
@@ -51,15 +53,36 @@ public class Member {
 	@Column(nullable = true)
 	private LocalDateTime deletedAt;
 
+	@ToString.Exclude
 	@OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private PasswordMember passwordMember;
 
+	@ToString.Exclude
 	@OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private SocialMember socialMember;
 
+	@ToString.Exclude
 	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<GroupRegistration> groupRegistrations = new ArrayList<>();
 
+	@ToString.Exclude
 	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<InterestedArticle> interestedArticles = new ArrayList<>();
+
+	@Transient
+	private boolean isFirstLogin = false;
+
+	public static Member createSocialMember(
+			String email, String nickname, LocalDateTime now, MemberRole role,
+			String oauthId, OauthType oauthType
+	) {
+		Member member = new Member();
+		member.role = role;
+		member.email = email;
+		member.nickname = nickname;
+		member.createdAt = now;
+		member.socialMember = SocialMember.of(member, oauthId, oauthType);
+		member.isFirstLogin = true;
+		return member;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/member/domain/PasswordMember.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/PasswordMember.java
@@ -24,6 +24,7 @@ public class PasswordMember {
 	private Long id;
 
 	@JoinColumn(name = "member_id", nullable = false)
+	@ToString.Exclude
 	@OneToOne(fetch = FetchType.LAZY)
 	private Member member;
 

--- a/src/main/java/org/unisphere/unisphere/member/domain/SocialMember.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/SocialMember.java
@@ -27,6 +27,7 @@ public class SocialMember {
 	private Long id;
 
 	@JoinColumn(name = "member_id", nullable = false)
+	@ToString.Exclude
 	@OneToOne(fetch = FetchType.LAZY)
 	private Member member;
 
@@ -36,4 +37,14 @@ public class SocialMember {
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private OauthType oauthType;
+
+	public static SocialMember of(
+			Member member, String oauthId, OauthType oauthType
+	) {
+		SocialMember socialMember = new SocialMember();
+		socialMember.member = member;
+		socialMember.oauthId = oauthId;
+		socialMember.oauthType = oauthType;
+		return socialMember;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/member/infrastructure/MemberRepository.java
+++ b/src/main/java/org/unisphere/unisphere/member/infrastructure/MemberRepository.java
@@ -1,8 +1,12 @@
 package org.unisphere.unisphere.member.infrastructure;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.unisphere.unisphere.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+	@Query("select m from Member m where m.email = :email")
+	Optional<Member> findByEmail(String email);
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -47,7 +47,7 @@ spring:
         provider:
           google:
             authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
-            token-uri: https://oauth2.googleapis.com/token
+            token-uri: https://www.googleapis.com/oauth2/v4/token
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
             jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
@@ -64,8 +64,8 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
-    jwt:
-      key: jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key
+  jwt:
+    key: jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key-jwt-key
 
 unisphere:
   server:


### PR DESCRIPTION
### ⚠️ (필독!!) 소셜 로그인 플로우

1. `/api/v1/auth/login/oauth-types/[소셜 로그인 타입]` 으로 이동합니다.
ex. `/api/v1/auth/login/oauth-types/google` 
2. 소셜 로그인을 진행합니다. (해당하는 소셜 기관 로그인 페이지에서 진행됨)
3. 로그인이 완료되면 `/api/v1/auth/login/oauth-types/google/callback`으로 이동됩니다. (이때 로그인 유저 정보를 리소스 서버가 우리 서버로 전달합니다.)
4. 우리 서버에서 해당 회원 정보를 DB에 저장하고, JWT 토큰을 발행하여 쿠키에 저장합니다.
5. `프론트엔드도메인/home?isFirstLogin={true | false}` 로 리다이렉션됩니다.
최초 로그인인 경우 로그인 즉시 아바타를 설정할 수 있어야할 것 같다는 생각이 들었습니다.
그래서 


<img width="735" alt="스크린샷 2023-11-29 오후 6 10 38" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/a205ce15-9373-49ac-a824-fcafc98a9552">

최초 로그인인 경우 -> isFirstLogin=true 라는 쿼리 스트링을 url에 담음.


<img width="692" alt="스크린샷 2023-11-29 오후 6 11 15" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/d6e81819-1657-48b2-9cd7-bd38ada75611">


최초 로그인이 아닌 경우 -> 쿼리 스트링 없이 /home으로 이동.

이렇게 구현해봤는데 제가 임의로 구현한 부분이라 다른 분들과도 논의가 필요할 것 같습니다..!

### Jwt 토큰에 들어가는 정보
<img width="669" alt="스크린샷 2023-11-29 오후 5 54 37" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/2cf57cf5-7f2c-48a4-b3e8-9061995b6744">

토큰에는 위와 같은 인증 정보가 담깁니다. 
memberId로 회원을 식별하고, role 정보로 그 회원이 일반 회원인지, 유니스피어 관리자인지 여부를 확인할 수 있습니다.
서버에서 관리하는 secret key를 이용하여 토큰의 유효성을 검증하기 때문에 토큰에 어떤 정보가 있는지는 확인할 수 있어도, 서버의 secret key로 토큰을 인코딩하지 않는 한 위조가 불가능합니다.


### 컨트롤러에 인증 적용 방법
<img width="799" alt="스크린샷 2023-11-29 오후 5 53 57" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/71180e5c-ab3c-4fb2-b29d-6dc2b2cf648e">

`@Secured(MemberRole.S_USER)` 어노테이션을 통해 토큰에서 S_USER 라는 role 정보가 있는지를 판단하여 `인가`를 수행합니다.
유니스피어 관리자만 사용할 수 있는 API에는 `@Secured(MemberRole.S_ADMIN)`과 같은 형식으로 작성하면 됩니다.


<img width="813" alt="스크린샷 2023-11-29 오후 5 58 35" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/866e67d1-57b5-42c2-b0b8-83ed8c97d7fe">
인증되지 않은 토큰을 사용하여 요청하는 경우 401을 응답하고,

<img width="810" alt="스크린샷 2023-11-29 오후 6 00 11" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/65a20474-81fe-468a-a479-cc0c2b749066">
인가되지 않은 토큰(S_ADMIN이 붙어있는 컨트롤러에 S_USER role만 가진 회원이 요청하는 경우 등)을 사용하여 요청하는 경우 403을 응답합니다.


<img width="408" alt="스크린샷 2023-11-29 오후 6 08 20" src="https://github.com/FF-UNI-SPHERE/UNISPHERE-SERVER/assets/83565255/a44e4640-959c-4923-ab3d-301fa676755b">

인증에 성공하면 컨트롤러의 매개변수로 `MemberSessionDto` 라는 객체를 받아오도록 설정했습니다.
여기에 들어있는 meberId를 바탕으로 로그인한 회원 정보를 DB에서 조회하여 Member 도메인 객체를 얻을 수 있습니다.
