### PR TITLE
[BE] 회원 아바타 조회 및 편집 API 구현

### DIFF
--- a/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
+++ b/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
@@ -44,6 +44,13 @@ public class ImageService {
 		return awsS3Manager.getPreSignedUrl(imageUrl);
 	}
 
+	public String getImageUrl(String imageUrl) {
+		if (Objects.isNull(imageUrl) || imageUrl.isBlank()) {
+			return null;
+		}
+		return awsS3Manager.getObjectUrl(imageUrl);
+	}
+
 	private List<String> getValidDirNameList() {
 		return List.of(ARTICLE_IMAGE_DIR, AVATAR_IMAGE_DIR, LOGO_IMAGE_DIR);
 	}

--- a/src/main/java/org/unisphere/unisphere/mapper/MemberMapper.java
+++ b/src/main/java/org/unisphere/unisphere/mapper/MemberMapper.java
@@ -1,0 +1,15 @@
+package org.unisphere.unisphere.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.unisphere.unisphere.member.domain.Member;
+import org.unisphere.unisphere.member.dto.response.MyAvatarResponseDto;
+
+@Mapper(componentModel = "spring")
+public interface MemberMapper {
+
+	MemberMapper INSTANCE = org.mapstruct.factory.Mappers.getMapper(MemberMapper.class);
+
+	@Mapping(source = "member.id", target = "memberId")
+	MyAvatarResponseDto toMyAvatarResponseDto(Member member);
+}

--- a/src/main/java/org/unisphere/unisphere/member/controller/MemberController.java
+++ b/src/main/java/org/unisphere/unisphere/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.annotation.Secured;
@@ -41,7 +42,7 @@ public class MemberController {
 			@LoginMemberInfo MemberSessionDto memberSessionDto
 	) {
 		log.info("Called getMyAvatar member: {}", memberSessionDto);
-		return MyAvatarResponseDto.builder().build();
+		return memberService.getMemberAvatar(memberSessionDto.getMemberId());
 	}
 
 	// 내 아바타 편집
@@ -54,11 +55,12 @@ public class MemberController {
 	@Secured(MemberRole.S_USER)
 	public MyAvatarResponseDto updateAvatar(
 			@LoginMemberInfo MemberSessionDto memberSessionDto,
-			@RequestBody MyAvatarUpdateRequestDto myAvatarUpdateRequestDto
+			@Valid @RequestBody MyAvatarUpdateRequestDto myAvatarUpdateRequestDto
 	) {
 		log.info("Called updateAvatar member: {}, avatarUpdateRequestDto: {}", memberSessionDto,
 				myAvatarUpdateRequestDto);
-		return MyAvatarResponseDto.builder().build();
+		return memberService.updateMemberAvatar(memberSessionDto.getMemberId(),
+				myAvatarUpdateRequestDto);
 	}
 
 	// 특정 회원 아바타 정보 조회

--- a/src/main/java/org/unisphere/unisphere/member/domain/Member.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/Member.java
@@ -85,4 +85,13 @@ public class Member {
 		member.isFirstLogin = true;
 		return member;
 	}
+
+	public void updateAvatar(String nickname, String preSignedAvatarImageUrl) {
+		if (nickname != null) {
+			this.nickname = nickname;
+		}
+		if (preSignedAvatarImageUrl != null) {
+			this.avatarImageUrl = preSignedAvatarImageUrl;
+		}
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/member/dto/request/MyAvatarUpdateRequestDto.java
+++ b/src/main/java/org/unisphere/unisphere/member/dto/request/MyAvatarUpdateRequestDto.java
@@ -16,6 +16,6 @@ public class MyAvatarUpdateRequestDto {
 	@Schema(description = "닉네임", example = "테스트", nullable = true)
 	private final String nickname;
 
-	@Schema(description = "pre-signed 아바타 이미지 URL", example = "avatar-images/random-string/image.png", nullable = true)
-	private final String preSignedAvatarImageUrl;
+	@Schema(description = "template 아바타 이미지 URL", example = "https://unisphere-main-image.s3.ap-northeast-2.amazonaws.com/avatar-images/random-string/avatar.png", nullable = true)
+	private final String templateAvatarImageUrl;
 }

--- a/src/main/java/org/unisphere/unisphere/member/service/MemberService.java
+++ b/src/main/java/org/unisphere/unisphere/member/service/MemberService.java
@@ -2,8 +2,16 @@ package org.unisphere.unisphere.member.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.unisphere.unisphere.auth.dto.MemberSessionDto;
+import org.unisphere.unisphere.image.service.ImageService;
+import org.unisphere.unisphere.mapper.MemberMapper;
+import org.unisphere.unisphere.member.domain.Member;
+import org.unisphere.unisphere.member.dto.request.MyAvatarUpdateRequestDto;
+import org.unisphere.unisphere.member.dto.response.MyAvatarResponseDto;
 import org.unisphere.unisphere.member.infrastructure.MemberRepository;
 
 @Service
@@ -13,4 +21,33 @@ import org.unisphere.unisphere.member.infrastructure.MemberRepository;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final MemberMapper memberMapper;
+	private final ImageService imageService;
+
+	public MyAvatarResponseDto getMemberAvatar(Long memberId) {
+		log.info("Called getMemberAvatar memberId: {}", memberId);
+
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new HttpClientErrorException(
+						HttpStatus.NOT_FOUND,
+						"memberId = " + memberId + " 에 해당하는 회원이 존재하지 않습니다."));
+		return memberMapper.toMyAvatarResponseDto(member);
+	}
+
+	public MyAvatarResponseDto updateMemberAvatar(Long memberId,
+			MyAvatarUpdateRequestDto myAvatarUpdateRequestDto) {
+		log.info("Called updateMemberAvatar memberId: {}, myAvatarUpdateRequestDto: {}", memberId,
+				myAvatarUpdateRequestDto);
+
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new HttpClientErrorException(
+						HttpStatus.NOT_FOUND,
+						"memberId = " + memberId + " 에 해당하는 회원이 존재하지 않습니다."));
+		String imageUrl = imageService.getImageUrl(
+				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
+		member.updateAvatar(myAvatarUpdateRequestDto.getNickname(),
+				imageUrl);
+		memberRepository.save(member);
+		return memberMapper.toMyAvatarResponseDto(member);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/member/service/MemberService.java
+++ b/src/main/java/org/unisphere/unisphere/member/service/MemberService.java
@@ -43,10 +43,11 @@ public class MemberService {
 				.orElseThrow(() -> new HttpClientErrorException(
 						HttpStatus.NOT_FOUND,
 						"memberId = " + memberId + " 에 해당하는 회원이 존재하지 않습니다."));
-		String imageUrl = imageService.getImageUrl(
-				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
+//      NOTE: 이미지 업로드를 PreSigned가 아닌 미리 약속한 템플릿 이미지 URL 전체 주소를 입력하도록 합니다.
+//		String imageUrl = imageService.getImageUrl(
+//				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
 		member.updateAvatar(myAvatarUpdateRequestDto.getNickname(),
-				imageUrl);
+				myAvatarUpdateRequestDto.getTemplateAvatarImageUrl());
 		memberRepository.save(member);
 		return memberMapper.toMyAvatarResponseDto(member);
 	}

--- a/src/main/java/org/unisphere/unisphere/member/validation/MemberUpdateValidation.java
+++ b/src/main/java/org/unisphere/unisphere/member/validation/MemberUpdateValidation.java
@@ -1,0 +1,20 @@
+package org.unisphere.unisphere.member.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MemberUpdateValidator.class)
+public @interface MemberUpdateValidation {
+
+	String message() default "MemberUpdateValidation";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/unisphere/unisphere/member/validation/MemberUpdateValidator.java
+++ b/src/main/java/org/unisphere/unisphere/member/validation/MemberUpdateValidator.java
@@ -1,0 +1,65 @@
+package org.unisphere.unisphere.member.validation;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.unisphere.unisphere.member.dto.request.MyAvatarUpdateRequestDto;
+
+public class MemberUpdateValidator implements
+		ConstraintValidator<MemberUpdateValidation, MyAvatarUpdateRequestDto> {
+
+	private static final String NICKNAME_REGEX = "^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$";
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile(NICKNAME_REGEX);
+	private static final int NICKNAME_MIN_LENGTH = 2;
+	private static final int NICKNAME_MAX_LENGTH = 16;
+	private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+			"jpeg", "jpg", "png");
+
+	private boolean validateNickname(MyAvatarUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getNickname() == null || value.getNickname().isEmpty()) {
+			return true;
+		}
+
+		if (value.getNickname().length() < NICKNAME_MIN_LENGTH
+				|| value.getNickname().length() > NICKNAME_MAX_LENGTH) {
+			context.buildConstraintViolationWithTemplate("닉네임은 " + NICKNAME_MIN_LENGTH
+							+ "자 이상 " + NICKNAME_MAX_LENGTH + "자 이하로 입력해주세요.")
+					.addConstraintViolation();
+			return false;
+		}
+
+		if (!NICKNAME_PATTERN.matcher(value.getNickname()).matches()) {
+			context.buildConstraintViolationWithTemplate("닉네임은 한글, 영문, 숫자만 입력 가능합니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateAvatarImageUrl(MyAvatarUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getPreSignedAvatarImageUrl() == null
+				|| value.getPreSignedAvatarImageUrl().isEmpty()) {
+			return true;
+		}
+
+		String[] split = value.getPreSignedAvatarImageUrl().split("\\.");
+		String imageType = split[split.length - 1];
+		if (!ALLOWED_IMAGE_TYPES.contains(imageType)) {
+			context.buildConstraintViolationWithTemplate("이미지는 " + ALLOWED_IMAGE_TYPES
+							+ " 형식만 지원합니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean isValid(MyAvatarUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		return validateNickname(value, context) && validateAvatarImageUrl(value, context);
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/member/validation/MemberUpdateValidator.java
+++ b/src/main/java/org/unisphere/unisphere/member/validation/MemberUpdateValidator.java
@@ -41,12 +41,12 @@ public class MemberUpdateValidator implements
 
 	private boolean validateAvatarImageUrl(MyAvatarUpdateRequestDto value,
 			ConstraintValidatorContext context) {
-		if (value.getPreSignedAvatarImageUrl() == null
-				|| value.getPreSignedAvatarImageUrl().isEmpty()) {
+		if (value.getTemplateAvatarImageUrl() == null
+				|| value.getTemplateAvatarImageUrl().isEmpty()) {
 			return true;
 		}
 
-		String[] split = value.getPreSignedAvatarImageUrl().split("\\.");
+		String[] split = value.getTemplateAvatarImageUrl().split("\\.");
 		String imageType = split[split.length - 1];
 		if (!ALLOWED_IMAGE_TYPES.contains(imageType)) {
 			context.buildConstraintViolationWithTemplate("이미지는 " + ALLOWED_IMAGE_TYPES

--- a/src/main/java/org/unisphere/unisphere/utils/ErrorResponse.java
+++ b/src/main/java/org/unisphere/unisphere/utils/ErrorResponse.java
@@ -1,0 +1,15 @@
+package org.unisphere.unisphere.utils;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ErrorResponse {
+
+	private Integer httpStatus;
+	private String exception;
+	private String message;
+	private List<FieldError> fieldErrors;
+}

--- a/src/main/java/org/unisphere/unisphere/utils/FieldError.java
+++ b/src/main/java/org/unisphere/unisphere/utils/FieldError.java
@@ -1,0 +1,13 @@
+package org.unisphere.unisphere.utils;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FieldError {
+
+	private String field;
+	private String errorCode;
+
+}

--- a/src/main/java/org/unisphere/unisphere/utils/RestExceptionHandler.java
+++ b/src/main/java/org/unisphere/unisphere/utils/RestExceptionHandler.java
@@ -1,0 +1,106 @@
+package org.unisphere.unisphere.utils;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice(annotations = RestController.class)
+public class RestExceptionHandler {
+
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ErrorResponse> handleBind(final BindException exception) {
+		BindingResult result = exception.getBindingResult();
+
+		String joinedMessages = result.getAllErrors().stream()
+				.map(DefaultMessageSourceResolvable::getDefaultMessage)
+				.collect(Collectors.joining(" "));
+
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.BAD_REQUEST.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(joinedMessages);
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgument(
+			final IllegalArgumentException exception) {
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.BAD_REQUEST.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(exception.getMessage());
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(HttpClientErrorException.class)
+	public ResponseEntity<ErrorResponse> handleHttpClientError(
+			final HttpClientErrorException exception) {
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(exception.getStatusCode().value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(exception.getMessage());
+		return new ResponseEntity<>(errorResponse, exception.getStatusCode());
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
+			final MethodArgumentNotValidException exception) {
+		final BindingResult bindingResult = exception.getBindingResult();
+		final List<FieldError> fieldErrors = bindingResult.getFieldErrors()
+				.stream()
+				.map(error -> {
+					final FieldError fieldError = new FieldError();
+					fieldError.setErrorCode(error.getCode());
+					fieldError.setField(error.getField());
+					return fieldError;
+				})
+				.collect(Collectors.toList());
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.BAD_REQUEST.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setFieldErrors(fieldErrors);
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(ResponseStatusException.class)
+	public ResponseEntity<ErrorResponse> handleResponseStatus(
+			final ResponseStatusException exception) {
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(exception.getStatus().value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(exception.getMessage());
+		return new ResponseEntity<>(errorResponse, exception.getStatus());
+	}
+
+	@ExceptionHandler(Throwable.class)
+	@ApiResponse(responseCode = "4xx/5xx", description = "Error")
+	public ResponseEntity<ErrorResponse> handleThrowable(final Throwable exception) {
+		exception.printStackTrace();
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(
+			final MethodArgumentTypeMismatchException exception) {
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.BAD_REQUEST.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(exception.getMessage());
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
+}


### PR DESCRIPTION
회원 아바타 조회 및 편집 API 구현했습니다.

회원 아바타 조회: GET `/api/v1/members/me/avatar`
회원 아바타 편집: PATCH `/api/v1/members/me/avatar`

최초 로그인 시, 소셜 기관에서 제공해준 이메일과 닉네임을 default로 사용합니다. (프로필 사진은 가져오지 않습니다.)
따라서 로그인 후, URL Query String의 `isFirstLogin=true`인 경우 PATCH `/api/v1/members/me/avatar`를 통해 아바타 이미지를 설정해야 합니다.
이때 템플릿으로 미리 정해둔 아바타 이미지 주소를 입력해야 합니다.
⚠️ 서버에 존재하는 템플릿 이미지 목록을 조회하는 API가 필요합니다.

회원 아바타 편집 시, 비어있는 필드는 무시하고 필드가 존재하는 경우에만 유효성 검증 후 변경됩니다.
