### PR TITLE
[BE] FEAT: 그룹 관련 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,23 +50,13 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'com.h2database:h2'
-}
-
-tasks.register('buildZip', Zip) {
-    from compileJava
-    from processResources
-    into('lib') {
-        from(configurations.runtimeClasspath) {
-            exclude 'tomcat-embed-*'
-        }
-    }
-}
-
-tasks.named('bootBuildImage') {
-    builder = 'paketobuildpacks/builder-jammy-base:latest'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {
+    environment 'SPRING_PROFILES_ACTIVE', 'test'
     useJUnitPlatform()
 }

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionController.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionController.java
@@ -82,7 +82,9 @@ public class ExceptionController {
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
 			final MethodArgumentNotValidException exception) {
 		final BindingResult bindingResult = exception.getBindingResult();
-		String message = bindingResult.getAllErrors().get(0).getDefaultMessage();
+		String message = bindingResult.getAllErrors().stream()
+				.map(DefaultMessageSourceResolvable::getDefaultMessage)
+				.collect(Collectors.joining(" "));
 		final ErrorResponse errorResponse = new ErrorResponse();
 		errorResponse.setStatus(HttpStatus.BAD_REQUEST.value());
 		errorResponse.setReason(exception.getClass().getSimpleName());

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
@@ -17,7 +17,7 @@ public enum ExceptionStatus {
 	NOT_GROUP_ADMIN(HttpStatus.FORBIDDEN, "그룹의 관리자가 아닙니다."),
 	ALREADY_GROUP_MEMBER(HttpStatus.CONFLICT, "이미 그룹에 가입되어 있거나 가입 요청이 처리 중입니다."),
 	ALREADY_APPROVED_MEMBER(HttpStatus.CONFLICT, "이미 가입 승인된 회원입니다."),
-	NOT_GROUP_MEMBER(HttpStatus.NOT_FOUND, "그룹에 가입되어 있지 않습니다."),
+	NOT_GROUP_MEMBER(HttpStatus.NOT_FOUND, "그룹에 가입되어 있지 않거나 가입 요청이 처리 중입니다."),
 	ALREADY_GROUP_ADMIN(HttpStatus.CONFLICT, "이미 그룹 관리자입니다."),
 	ALREADY_GROUP_OWNER(HttpStatus.CONFLICT, "이미 그룹 소유자입니다."),
 

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
@@ -14,6 +14,10 @@ public enum ExceptionStatus {
 	ALREADY_EXIST_GROUP_NAME(HttpStatus.CONFLICT, "이미 존재하는 그룹 이름입니다."),
 	NOT_FOUND_GROUP(HttpStatus.NOT_FOUND, "그룹이 존재하지 않습니다."),
 	NOT_GROUP_OWNER(HttpStatus.FORBIDDEN, "그룹의 소유자가 아닙니다."),
+	NOT_GROUP_ADMIN(HttpStatus.FORBIDDEN, "그룹의 관리자가 아닙니다."),
+	ALREADY_GROUP_MEMBER(HttpStatus.CONFLICT, "이미 그룹에 가입되어 있거나 가입 요청이 처리 중입니다."),
+	ALREADY_APPROVED_MEMBER(HttpStatus.CONFLICT, "이미 가입 승인된 회원입니다."),
+	NOT_GROUP_MEMBER(HttpStatus.NOT_FOUND, "그룹에 가입되어 있지 않습니다."),
 
 	//	Image
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
@@ -20,6 +20,7 @@ public enum ExceptionStatus {
 	NOT_GROUP_MEMBER(HttpStatus.NOT_FOUND, "그룹에 가입되어 있지 않거나 가입 요청이 처리 중입니다."),
 	ALREADY_GROUP_ADMIN(HttpStatus.CONFLICT, "이미 그룹 관리자입니다."),
 	ALREADY_GROUP_OWNER(HttpStatus.CONFLICT, "이미 그룹 소유자입니다."),
+	CANNOT_KICK_HIGHER_RANK_MEMBER(HttpStatus.FORBIDDEN, "자신보다 높거나 같은 등급의 그룹 회원을 추방할 수 없습니다."),
 
 	//	Image
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
@@ -19,6 +19,7 @@ public enum ExceptionStatus {
 	ALREADY_APPROVED_MEMBER(HttpStatus.CONFLICT, "이미 가입 승인된 회원입니다."),
 	NOT_GROUP_MEMBER(HttpStatus.NOT_FOUND, "그룹에 가입되어 있지 않습니다."),
 	ALREADY_GROUP_ADMIN(HttpStatus.CONFLICT, "이미 그룹 관리자입니다."),
+	ALREADY_GROUP_OWNER(HttpStatus.CONFLICT, "이미 그룹 소유자입니다."),
 
 	//	Image
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
@@ -18,6 +18,7 @@ public enum ExceptionStatus {
 	ALREADY_GROUP_MEMBER(HttpStatus.CONFLICT, "이미 그룹에 가입되어 있거나 가입 요청이 처리 중입니다."),
 	ALREADY_APPROVED_MEMBER(HttpStatus.CONFLICT, "이미 가입 승인된 회원입니다."),
 	NOT_GROUP_MEMBER(HttpStatus.NOT_FOUND, "그룹에 가입되어 있지 않습니다."),
+	ALREADY_GROUP_ADMIN(HttpStatus.CONFLICT, "이미 그룹 관리자입니다."),
 
 	//	Image
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),

--- a/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
+++ b/src/main/java/org/unisphere/unisphere/exception/ExceptionStatus.java
@@ -12,12 +12,13 @@ public enum ExceptionStatus {
 
 	//	Group
 	ALREADY_EXIST_GROUP_NAME(HttpStatus.CONFLICT, "이미 존재하는 그룹 이름입니다."),
+	NOT_FOUND_GROUP(HttpStatus.NOT_FOUND, "그룹이 존재하지 않습니다."),
+	NOT_GROUP_OWNER(HttpStatus.FORBIDDEN, "그룹의 소유자가 아닙니다."),
 
 	//	Image
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),
 	FAILED_TO_DELETE_IMAGE(HttpStatus.BAD_GATEWAY, "이미지 삭제에 실패했습니다. 다시 시도해주세요."),
 	;
-
 	private final int status;
 	private final String message;
 	private final String reason;

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -209,6 +209,20 @@ public class GroupController {
 				targetMemberId);
 	}
 
+	@Operation(summary = "단체 관리자 임명", description = "특정 회원을 단체 관리자로 임명합니다. 단체 생성자만 호출할 수 있습니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok")
+	})
+	@PatchMapping(value = "/{groupId}/members/{memberId}/admin/appoint")
+	@Secured(MemberRole.S_USER)
+	public void appointGroupAdmin(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("groupId") Long groupId,
+			@PathVariable("memberId") Long targetMemberId
+	) {
+		groupFacadeService.appointGroupAdmin(memberSessionDto.getMemberId(), groupId,
+				targetMemberId);
+	}
 
 	// 단체 탈퇴
 	// DELETE /api/v1/groups/{groupId}/unregister (pending)

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -256,7 +256,7 @@ public class GroupController {
 			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId
 	) {
-//		groupFacadeService.deleteGroup(memberSessionDto.getMemberId(), groupId);
+		groupFacadeService.deleteGroup(memberSessionDto.getMemberId(), groupId);
 	}
 
 	// 단체 탈퇴

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -70,7 +70,7 @@ public class GroupController {
 				PageRequest.of(page, size));
 	}
 
-	@Operation(summary = "특정 회원이 속한 단체 목록 조회", description = "특정 회원이 속한 단체 목록을 조회합니다.", deprecated = true)
+	@Operation(summary = "특정 회원이 속한 단체 목록 조회", description = "특정 회원이 속한 단체 목록을 조회합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
 	})
@@ -111,8 +111,6 @@ public class GroupController {
 				groupAvatarUpdateRequestDto);
 	}
 
-	// 특정 단체의 홈피 정보 조회
-	// GET /api/v1/groups/{groupId}/home-page
 	@Operation(summary = "특정 단체의 홈피 정보 조회", description = "특정 단체의 홈피 정보를 조회합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
@@ -120,26 +118,24 @@ public class GroupController {
 	@GetMapping(value = "/{groupId}/home-page")
 	@Secured(MemberRole.S_USER)
 	public GroupHomePageResponseDto getGroupHomePage(
-			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId
 	) {
-		return GroupHomePageResponseDto.builder().build();
+		return groupFacadeService.getGroupHomePage(groupId);
 	}
 
-	// 특정 단체의 홈피 정보 편집
-	// PUT /api/v1/groups/{groupId}/home-page
 	@Operation(summary = "특정 단체의 홈피 정보 편집", description = "특정 단체의 홈피 정보를 편집합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
 	})
 	@PutMapping(value = "/{groupId}/home-page")
 	@Secured(MemberRole.S_USER)
-	public GroupHomePageResponseDto updateGroupHomePage(
+	public GroupHomePageResponseDto putGroupHomePage(
 			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId,
-			@RequestBody GroupHomePageUpdateRequestDto groupHomePageUpdateRequestDto
+			@Valid @RequestBody GroupHomePageUpdateRequestDto groupHomePageUpdateRequestDto
 	) {
-		return GroupHomePageResponseDto.builder().build();
+		return groupFacadeService.putGroupHomePage(memberSessionDto.getMemberId(), groupId,
+				groupHomePageUpdateRequestDto);
 	}
 
 	// 특정 단체의 속한 회원 목록 조회

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -209,7 +209,7 @@ public class GroupController {
 				targetMemberId);
 	}
 
-	@Operation(summary = "단체 관리자 임명", description = "특정 회원을 단체 관리자로 임명합니다. 단체 생성자만 호출할 수 있습니다.")
+	@Operation(summary = "단체 관리자 임명", description = "특정 회원을 단체 관리자로 임명합니다. 단체 소유자만 호출할 수 있습니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok")
 	})
@@ -224,11 +224,46 @@ public class GroupController {
 				targetMemberId);
 	}
 
+	@Operation(
+			summary = "단체 소유자 위임",
+			description = "특정 단체의 소유자를 변경합니다. 단체 소유자만 호출할 수 있습니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok")
+	})
+	@PatchMapping(value = "/{groupId}/members/{memberId}/owner/appoint")
+	@Secured(MemberRole.S_USER)
+	public void appointGroupOwner(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("groupId") Long groupId,
+			@PathVariable("memberId") Long targetMemberId
+	) {
+		groupFacadeService.appointGroupOwner(memberSessionDto.getMemberId(), groupId,
+				targetMemberId);
+	}
+
+	@Operation(
+			summary = "단체 삭제",
+			description = "특정 단체를 삭제합니다. 단체 소유자만 호출할 수 있습니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content")
+	})
+	@DeleteMapping(value = "/{groupId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Secured(MemberRole.S_USER)
+	public void deleteGroup(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("groupId") Long groupId
+	) {
+//		groupFacadeService.deleteGroup(memberSessionDto.getMemberId(), groupId);
+	}
+
 	// 단체 탈퇴
 	// DELETE /api/v1/groups/{groupId}/unregister (pending)
 	@Operation(
 			summary = "단체 탈퇴",
-			description = "특정 단체를 떠납니다. 단체 생성자가 요청하면 생성자를 다른 단체 관리자나 단체 회원에게 위임하고, 혼자 남아있는 상태에서 요청한 경우에는 단체가 삭제됩니다.",
+			description = "특정 단체를 떠납니다. 단체 소유자가 요청하면 소유자를 다른 단체 관리자나 단체 회원에게 위임하고, 혼자 남아있는 상태에서 요청한 경우에는 단체가 삭제됩니다.",
 			deprecated = true
 	)
 	@ApiResponses(value = {

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -70,9 +70,6 @@ public class GroupController {
 				PageRequest.of(page, size));
 	}
 
-
-	// 특정 회원이 속한 단체 목록 조회
-	// GET /api/v1/groups/members/{memberId}?page={page}&size={size} (pending)
 	@Operation(summary = "특정 회원이 속한 단체 목록 조회", description = "특정 회원이 속한 단체 목록을 조회합니다.", deprecated = true)
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
@@ -80,16 +77,13 @@ public class GroupController {
 	@GetMapping(value = "/members/{memberId}")
 	@Secured(MemberRole.S_USER)
 	public GroupListResponseDto getMemberGroups(
-			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("memberId") Long targetMemberId,
 			@RequestParam(defaultValue = "0") int page,
 			@RequestParam(defaultValue = "10") int size
 	) {
-		return GroupListResponseDto.builder().build();
+		return groupFacadeService.getMemberGroups(targetMemberId, PageRequest.of(page, size));
 	}
 
-	// 특정 단체 아바타 조회
-	// GET /api/v1/groups/{groupId}/avatar
 	@Operation(summary = "특정 단체 아바타 조회", description = "특정 단체 아바타를 조회합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
@@ -97,14 +91,11 @@ public class GroupController {
 	@GetMapping(value = "/{groupId}/avatar")
 	@Secured(MemberRole.S_USER)
 	public GroupAvatarResponseDto getGroupAvatar(
-			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId
 	) {
-		return GroupAvatarResponseDto.builder().build();
+		return groupFacadeService.getGroupAvatar(groupId);
 	}
 
-	// 특정 단체 아바타 편집
-	// PATCH /api/v1/groups/{groupId}/avatar
 	@Operation(summary = "특정 단체 아바타 편집", description = "특정 단체 아바타를 편집합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
@@ -114,9 +105,10 @@ public class GroupController {
 	public GroupAvatarResponseDto updateGroupAvatar(
 			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId,
-			@RequestBody GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto
+			@Valid @RequestBody GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto
 	) {
-		return GroupAvatarResponseDto.builder().build();
+		return groupFacadeService.updateGroupAvatar(memberSessionDto.getMemberId(), groupId,
+				groupAvatarUpdateRequestDto);
 	}
 
 	// 특정 단체의 홈피 정보 조회

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -180,8 +180,6 @@ public class GroupController {
 	) {
 	}
 
-	// 단체 가입 요청
-	// POST /api/v1/groups/{groupId}/register
 	@Operation(summary = "단체 가입 요청", description = "특정 단체에 가입 요청합니다. 이미 가입한 회원은 요청할 수 없습니다. 단체 관리자의 승인이 필요합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "201", description = "created"),
@@ -189,14 +187,13 @@ public class GroupController {
 	@PostMapping(value = "/{groupId}/register")
 	@ResponseStatus(HttpStatus.CREATED)
 	@Secured(MemberRole.S_USER)
-	public void registerGroup(
+	public void requestRegisterGroup(
 			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId
 	) {
+		groupFacadeService.requestRegisterGroup(memberSessionDto.getMemberId(), groupId);
 	}
 
-	// 단체 가입 승인
-	// PATCH /api/v1/groups/{groupId}/members/{memberId}/register/approve
 	@Operation(summary = "단체 가입 승인", description = "특정 회원의 단체 가입을 승인합니다. 단체 관리자만 호출할 수 있습니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok")
@@ -208,6 +205,8 @@ public class GroupController {
 			@PathVariable("groupId") Long groupId,
 			@PathVariable("memberId") Long targetMemberId
 	) {
+		groupFacadeService.approveGroupRegister(memberSessionDto.getMemberId(), groupId,
+				targetMemberId);
 	}
 
 

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -138,21 +138,18 @@ public class GroupController {
 				groupHomePageUpdateRequestDto);
 	}
 
-	// 특정 단체의 속한 회원 목록 조회
-	// GET /api/v1/groups/{groupId}/members?page={page}&size={size} (pending)
-	@Operation(summary = "특정 단체의 속한 회원 목록 조회", description = "특정 단체의 속한 회원 목록을 조회합니다.", deprecated = true)
+	@Operation(summary = "특정 단체에 속한 회원 목록 조회", description = "특정 단체의 속한 회원 목록을 조회합니다.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "ok"),
 	})
 	@GetMapping(value = "/{groupId}/members")
 	@Secured(MemberRole.S_USER)
 	public GroupMemberListResponseDto getGroupMembers(
-			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId,
 			@RequestParam(defaultValue = "0") int page,
 			@RequestParam(defaultValue = "10") int size
 	) {
-		return GroupMemberListResponseDto.builder().build();
+		return groupFacadeService.getGroupMembers(groupId, PageRequest.of(page, size));
 	}
 
 	@Operation(summary = "단체 생성 요청", description = "단체를 생성을 요청합니다. 유니스피어 관리자의 승인이 필요합니다.")

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -282,12 +282,9 @@ public class GroupController {
 	// 초대 코드로 단체 가입
 	// POST /api/v1/groups/{groupId}/members/{memberId}/accept?code={code} (pending)
 
-	// 특정 회원을 단체에서 추방
-	// DELETE /api/v1/groups/{groupId}/members/{memberId}/kick (pending)
 	@Operation(
 			summary = "단체에서 회원 추방",
-			description = "특정 단체에서 특정 회원을 추방합니다. 단체 관리자 이상의 등급만 호출할 수 있으며 자신보다 등급이 높거나 같은 대상에게는 호출할 수 없습니다.",
-			deprecated = true
+			description = "특정 단체에서 특정 회원을 추방합니다. 단체 관리자 이상의 등급만 호출할 수 있으며 자신보다 등급이 높거나 같은 대상에게는 호출할 수 없습니다."
 	)
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "204", description = "no content")
@@ -300,5 +297,7 @@ public class GroupController {
 			@PathVariable("groupId") Long groupId,
 			@PathVariable("memberId") Long targetMemberId
 	) {
+		groupFacadeService.kickMemberFromGroup(memberSessionDto.getMemberId(), groupId,
+				targetMemberId);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
+++ b/src/main/java/org/unisphere/unisphere/group/controller/GroupController.java
@@ -259,12 +259,9 @@ public class GroupController {
 		groupFacadeService.deleteGroup(memberSessionDto.getMemberId(), groupId);
 	}
 
-	// 단체 탈퇴
-	// DELETE /api/v1/groups/{groupId}/unregister (pending)
 	@Operation(
 			summary = "단체 탈퇴",
-			description = "특정 단체를 떠납니다. 단체 소유자가 요청하면 소유자를 다른 단체 관리자나 단체 회원에게 위임하고, 혼자 남아있는 상태에서 요청한 경우에는 단체가 삭제됩니다.",
-			deprecated = true
+			description = "특정 단체를 떠납니다. 단체 소유자가 요청하면 소유자를 다른 단체 관리자나 단체 회원에게 위임하고, 혼자 남아있는 상태에서 요청한 경우에는 단체가 삭제됩니다."
 	)
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "204", description = "no content")
@@ -276,6 +273,7 @@ public class GroupController {
 			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("groupId") Long groupId
 	) {
+		groupFacadeService.unregisterGroup(memberSessionDto.getMemberId(), groupId);
 	}
 
 	// 특정 회원을 단체에 초대

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -108,13 +108,4 @@ public class Group {
 		this.email = email;
 		this.groupSiteUrl = groupSiteUrl;
 	}
-
-	public void setOwnerMember(Member targetMember) {
-		this.ownerMember = targetMember;
-	}
-
-	public void unRegisterMember(Member member) {
-		this.groupRegistrations.removeIf(
-				groupRegistration -> groupRegistration.getMember().equals(member));
-	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -75,4 +75,17 @@ public class Group {
 		group.logoImageUrl = logoImageUrl;
 		return group;
 	}
+
+	public void updateAvatar(String name, String preSignedAvatarImageUrl) {
+		if (name != null && !name.isEmpty()) {
+			this.name = name;
+		}
+		if (preSignedAvatarImageUrl != null && !preSignedAvatarImageUrl.isEmpty()) {
+			this.avatarImageUrl = preSignedAvatarImageUrl;
+		}
+	}
+
+	public boolean isOwner(Member member) {
+		return this.ownerMember.equals(member);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -88,4 +88,12 @@ public class Group {
 	public boolean isOwner(Member member) {
 		return this.ownerMember.equals(member);
 	}
+
+	public void putHomePage(String preSignedLogoImageUrl, String content, String email,
+			String groupSiteUrl) {
+		this.logoImageUrl = preSignedLogoImageUrl;
+		this.content = content;
+		this.email = email;
+		this.groupSiteUrl = groupSiteUrl;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -120,4 +120,8 @@ public class Group {
 		this.email = email;
 		this.groupSiteUrl = groupSiteUrl;
 	}
+
+	public void setOwnerMember(Member targetMember) {
+		this.ownerMember = targetMember;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -124,4 +124,9 @@ public class Group {
 	public void setOwnerMember(Member targetMember) {
 		this.ownerMember = targetMember;
 	}
+
+	public void unRegisterMember(Member member) {
+		this.groupRegistrations.removeIf(
+				groupRegistration -> groupRegistration.getMember().equals(member));
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -97,20 +97,8 @@ public class Group {
 		}
 	}
 
-	public boolean isOwner(Member member) {
+	public boolean isGroupOwner(Member member) {
 		return this.ownerMember.equals(member);
-	}
-
-	public boolean isGroupAdmin(Member member) {
-		return isOwner(member) ||
-				this.groupRegistrations.stream()
-						.anyMatch(groupRegistration -> groupRegistration.getMember().equals(member)
-								&& groupRegistration.getRole().equals(GroupRole.ADMIN));
-	}
-
-	public boolean isGroupMember(Member member) {
-		return this.groupRegistrations.stream()
-				.anyMatch(groupRegistration -> groupRegistration.getMember().equals(member));
 	}
 
 	public void putHomePage(String preSignedLogoImageUrl, String content, String email,

--- a/src/main/java/org/unisphere/unisphere/group/domain/Group.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/Group.java
@@ -64,6 +64,18 @@ public class Group {
 	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	private Member ownerMember;
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Group group = (Group) o;
+		return getId().equals(group.getId());
+	}
+
 	public static Group createGroup(LocalDateTime now, Member member, String name, String summary,
 			String logoImageUrl) {
 		Group group = new Group();
@@ -87,6 +99,18 @@ public class Group {
 
 	public boolean isOwner(Member member) {
 		return this.ownerMember.equals(member);
+	}
+
+	public boolean isGroupAdmin(Member member) {
+		return isOwner(member) ||
+				this.groupRegistrations.stream()
+						.anyMatch(groupRegistration -> groupRegistration.getMember().equals(member)
+								&& groupRegistration.getRole().equals(GroupRole.ADMIN));
+	}
+
+	public boolean isGroupMember(Member member) {
+		return this.groupRegistrations.stream()
+				.anyMatch(groupRegistration -> groupRegistration.getMember().equals(member));
 	}
 
 	public void putHomePage(String preSignedLogoImageUrl, String content, String email,

--- a/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
@@ -69,4 +69,8 @@ public class GroupRegistration {
 	public void appointAdmin() {
 		this.role = GroupRole.ADMIN;
 	}
+
+	public void appointOwner() {
+		this.role = GroupRole.OWNER;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
@@ -1,6 +1,7 @@
 package org.unisphere.unisphere.group.domain;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -39,6 +40,20 @@ public class GroupRegistration {
 	@Column(nullable = true)
 	private LocalDateTime registeredAt;
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		GroupRegistration that = (GroupRegistration) o;
+
+		return Objects.equals(id, that.id);
+	}
+
 	public static GroupRegistration createOwnerRegistration(LocalDateTime now, Member ownerMember,
 			Group group) {
 		GroupRegistration groupRegistration = new GroupRegistration();
@@ -62,15 +77,31 @@ public class GroupRegistration {
 		return groupRegistration;
 	}
 
-	public void approve() {
-		this.registeredAt = LocalDateTime.now();
+	public void approveRegistration(LocalDateTime now) {
+		this.registeredAt = now;
 	}
 
-	public void appointAdmin() {
+	public void appointAsAdmin() {
 		this.role = GroupRole.ADMIN;
 	}
 
-	public void appointOwner() {
+	public void appointAsOwner() {
 		this.role = GroupRole.OWNER;
+	}
+
+	public boolean isOwner() {
+		return this.role == GroupRole.OWNER;
+	}
+
+	public boolean isAdmin() {
+		return this.role == GroupRole.ADMIN;
+	}
+
+	public boolean isOwner(Member member) {
+		return this.member.equals(member) && this.role == GroupRole.OWNER;
+	}
+
+	public boolean isAdmin(Member member) {
+		return isOwner(member) || this.role == GroupRole.ADMIN;
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
@@ -65,4 +65,8 @@ public class GroupRegistration {
 	public void approve() {
 		this.registeredAt = LocalDateTime.now();
 	}
+
+	public void appointAdmin() {
+		this.role = GroupRole.ADMIN;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
@@ -39,7 +39,8 @@ public class GroupRegistration {
 	@Column(nullable = true)
 	private LocalDateTime registeredAt;
 
-	public static GroupRegistration of(LocalDateTime now, Member ownerMember, Group group) {
+	public static GroupRegistration createOwnerRegistration(LocalDateTime now, Member ownerMember,
+			Group group) {
 		GroupRegistration groupRegistration = new GroupRegistration();
 		groupRegistration.id = new GroupRegistrationCompositeKey(ownerMember.getId(),
 				group.getId());
@@ -48,5 +49,20 @@ public class GroupRegistration {
 		groupRegistration.role = GroupRole.OWNER;
 		groupRegistration.registeredAt = now;
 		return groupRegistration;
+	}
+
+	public static GroupRegistration of(Member member, Group group, GroupRole role) {
+		GroupRegistration groupRegistration = new GroupRegistration();
+		groupRegistration.id = new GroupRegistrationCompositeKey(member.getId(),
+				group.getId());
+		groupRegistration.member = member;
+		groupRegistration.group = group;
+		groupRegistration.role = role;
+		groupRegistration.registeredAt = null;
+		return groupRegistration;
+	}
+
+	public void approve() {
+		this.registeredAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
+++ b/src/main/java/org/unisphere/unisphere/group/domain/GroupRegistration.java
@@ -66,14 +66,15 @@ public class GroupRegistration {
 		return groupRegistration;
 	}
 
-	public static GroupRegistration of(Member member, Group group, GroupRole role) {
+	public static GroupRegistration of(Member member, Group group, GroupRole role,
+			LocalDateTime now) {
 		GroupRegistration groupRegistration = new GroupRegistration();
 		groupRegistration.id = new GroupRegistrationCompositeKey(member.getId(),
 				group.getId());
 		groupRegistration.member = member;
 		groupRegistration.group = group;
 		groupRegistration.role = role;
-		groupRegistration.registeredAt = null;
+		groupRegistration.registeredAt = now;
 		return groupRegistration;
 	}
 

--- a/src/main/java/org/unisphere/unisphere/group/dto/GroupMemberDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/GroupMemberDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+import org.unisphere.unisphere.group.domain.GroupRole;
 
 @AllArgsConstructor
 @Getter
@@ -21,4 +23,7 @@ public class GroupMemberDto {
 
 	@Schema(description = "회원 아바타 이미지 URL", example = "https://unisphere.org/avatar-images/random-string/avatar-image.png")
 	private final String avatarImageUrl;
+
+	@Schema(description = "단체에서의 회원 등급", example = "OWNER")
+	private final GroupRole role;
 }

--- a/src/main/java/org/unisphere/unisphere/group/dto/GroupMemberDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/GroupMemberDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.unisphere.unisphere.auth.domain.MemberRole;
 import org.unisphere.unisphere.group.domain.GroupRole;
 
@@ -13,6 +14,7 @@ import org.unisphere.unisphere.group.domain.GroupRole;
 @ToString
 @Builder
 @Schema(description = "단체에 속한 회원 정보")
+@FieldNameConstants
 public class GroupMemberDto {
 
 	@Schema(description = "회원 ID", example = "1")

--- a/src/main/java/org/unisphere/unisphere/group/dto/GroupPreviewDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/GroupPreviewDto.java
@@ -1,6 +1,7 @@
 package org.unisphere.unisphere.group.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,4 +25,7 @@ public class GroupPreviewDto {
 
 	@Schema(description = "단체 요약 설명", example = "유니스피어는 멋진 단체에요.")
 	private final String summary;
+
+	@Schema(description = "단체 승인일", example = "2021-01-01T00:00:00")
+	private final LocalDateTime approvedAt;
 }

--- a/src/main/java/org/unisphere/unisphere/group/dto/GroupPreviewDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/GroupPreviewDto.java
@@ -6,12 +6,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Getter
 @ToString
 @Builder
 @Schema(description = "단체 Preview 정보")
+@FieldNameConstants
 public class GroupPreviewDto {
 
 	@Schema(description = "단체 ID", example = "1")

--- a/src/main/java/org/unisphere/unisphere/group/dto/request/GroupAvatarUpdateRequestDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/request/GroupAvatarUpdateRequestDto.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.unisphere.unisphere.group.validation.AvatarUpdateValidation;
 
 @AllArgsConstructor
 @Getter
 @ToString
 @Builder
 @Schema(description = "그룹 아바타 정보 수정 요청")
+@AvatarUpdateValidation
 public class GroupAvatarUpdateRequestDto {
 
 	@Schema(description = "그룹명", example = "유니스피어", nullable = true)

--- a/src/main/java/org/unisphere/unisphere/group/dto/request/GroupHomePageUpdateRequestDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/request/GroupHomePageUpdateRequestDto.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.unisphere.unisphere.group.validation.GroupHomePageUpdateValidation;
 
 @AllArgsConstructor
 @Getter
 @ToString
 @Builder
 @Schema(description = "단체 홈페이지 수정 요청")
+@GroupHomePageUpdateValidation
 public class GroupHomePageUpdateRequestDto {
 
 	@Schema(description = "단체 로고 이미지 URL", example = "logo-images/random-string/logo-image.png", nullable = true)

--- a/src/main/java/org/unisphere/unisphere/group/dto/response/GroupAvatarResponseDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/response/GroupAvatarResponseDto.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Getter
 @ToString
 @Builder
 @Schema(description = "단체 아바타 정보")
+@FieldNameConstants
 public class GroupAvatarResponseDto {
 
 	@Schema(description = "단체 ID", example = "1")

--- a/src/main/java/org/unisphere/unisphere/group/dto/response/GroupHomePageResponseDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/response/GroupHomePageResponseDto.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Getter
 @ToString
 @Builder
 @Schema(description = "단체 홈피 조회 응답")
+@FieldNameConstants
 public class GroupHomePageResponseDto {
 
 	@Schema(description = "단체 ID", example = "1")

--- a/src/main/java/org/unisphere/unisphere/group/dto/response/GroupListResponseDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/response/GroupListResponseDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.unisphere.unisphere.group.dto.GroupPreviewDto;
 
 @AllArgsConstructor
@@ -14,6 +15,7 @@ import org.unisphere.unisphere.group.dto.GroupPreviewDto;
 @ToString
 @Builder
 @Schema(description = "단체 목록 조회 응답")
+@FieldNameConstants
 public class GroupListResponseDto {
 
 	@ArraySchema(schema = @Schema(implementation = GroupPreviewDto.class))

--- a/src/main/java/org/unisphere/unisphere/group/dto/response/GroupMemberListResponseDto.java
+++ b/src/main/java/org/unisphere/unisphere/group/dto/response/GroupMemberListResponseDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.unisphere.unisphere.group.dto.GroupMemberDto;
 
 @AllArgsConstructor
@@ -14,6 +15,7 @@ import org.unisphere.unisphere.group.dto.GroupMemberDto;
 @ToString
 @Builder
 @Schema(description = "단체에 속한 회원 목록 정보")
+@FieldNameConstants
 public class GroupMemberListResponseDto {
 
 	@ArraySchema(arraySchema = @Schema(description = "단체에 속한 회원 목록", implementation = GroupMemberDto.class))

--- a/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
+++ b/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
@@ -10,4 +10,7 @@ public interface GroupRegistrationRepository extends JpaRepository<GroupRegistra
 
 	@Query("select gr from group_registration gr where gr.member.id = :memberId")
 	Page<GroupRegistration> findAllByMemberId(Long memberId, Pageable pageable);
+
+	@Query("select gr from group_registration gr where gr.group.id = :groupId")
+	Page<GroupRegistration> findAllByGroupId(Long groupId, Pageable pageable);
 }

--- a/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
+++ b/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
+import org.unisphere.unisphere.group.domain.GroupRole;
 
 public interface GroupRegistrationRepository extends JpaRepository<GroupRegistration, Long> {
 
@@ -17,4 +18,7 @@ public interface GroupRegistrationRepository extends JpaRepository<GroupRegistra
 
 	@Query("select gr from group_registration gr where gr.group.id = :groupId and gr.member.id = :memberId")
 	Optional<GroupRegistration> findByGroupIdAndMemberId(Long groupId, Long memberId);
+
+	@Query("select gr from group_registration gr where gr.role = :role")
+	Optional<GroupRegistration> findByRole(GroupRole role);
 }

--- a/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
+++ b/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
@@ -19,6 +19,16 @@ public interface GroupRegistrationRepository extends JpaRepository<GroupRegistra
 	@Query("select gr from group_registration gr where gr.group.id = :groupId and gr.member.id = :memberId")
 	Optional<GroupRegistration> findByGroupIdAndMemberId(Long groupId, Long memberId);
 
+	@Query("select gr from group_registration gr where gr.group.id = :groupId and gr.member.id = :memberId and gr.registeredAt is not null")
+	Optional<GroupRegistration> findByGroupIdAndMemberIdAndRegisteredAtNotNull(Long groupId,
+			Long memberId);
+
 	@Query("select gr from group_registration gr where gr.role = :role")
 	Optional<GroupRegistration> findByRole(GroupRole role);
+
+	@Query("select gr from group_registration gr where gr.group.id = :groupId and gr.role = :role and gr.registeredAt != null order by gr.registeredAt asc")
+	Optional<GroupRegistration> findByGroupIdAndRoleAndRegisteredAtNotNullOrderByRegisteredAtAsc(
+			Long groupId,
+			GroupRole role
+	);
 }

--- a/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
+++ b/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
@@ -1,5 +1,6 @@
 package org.unisphere.unisphere.group.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,4 +32,8 @@ public interface GroupRegistrationRepository extends JpaRepository<GroupRegistra
 			Long groupId,
 			GroupRole role
 	);
+
+	@Query("select gr from group_registration gr where gr.group.id = :groupId and gr.role in :roles and gr.registeredAt != null")
+	List<GroupRegistration> findAllByGroupIdAndRoleAndRegisteredAtNotNull(Long groupId,
+			List<GroupRole> roles);
 }

--- a/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
+++ b/src/main/java/org/unisphere/unisphere/group/infrastructure/GroupRegistrationRepository.java
@@ -1,5 +1,6 @@
 package org.unisphere.unisphere.group.infrastructure;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,7 @@ public interface GroupRegistrationRepository extends JpaRepository<GroupRegistra
 
 	@Query("select gr from group_registration gr where gr.group.id = :groupId")
 	Page<GroupRegistration> findAllByGroupId(Long groupId, Pageable pageable);
+
+	@Query("select gr from group_registration gr where gr.group.id = :groupId and gr.member.id = :memberId")
+	Optional<GroupRegistration> findByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -10,6 +10,7 @@ import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
 import org.unisphere.unisphere.group.dto.request.GroupAvatarUpdateRequestDto;
 import org.unisphere.unisphere.group.dto.request.GroupCreateRequestDto;
+import org.unisphere.unisphere.group.dto.request.GroupHomePageUpdateRequestDto;
 import org.unisphere.unisphere.group.infrastructure.GroupRegistrationRepository;
 import org.unisphere.unisphere.group.infrastructure.GroupRepository;
 import org.unisphere.unisphere.image.service.ImageService;
@@ -55,11 +56,28 @@ public class GroupCommandService {
 		groupRegistrationRepository.save(groupRegistration);
 	}
 
+	/**
+	 * 그룹 아바타 수정 요청
+	 *
+	 * @param group                       그룹
+	 * @param groupAvatarUpdateRequestDto 그룹 아바타 수정 요청 DTO
+	 */
 	public void updateGroupAvatar(Group group,
 			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
 		group.updateAvatar(
 				groupAvatarUpdateRequestDto.getName(),
 				groupAvatarUpdateRequestDto.getPreSignedAvatarImageUrl()
+		);
+		groupRepository.save(group);
+	}
+
+	public void putGroupHomePage(Group group,
+			GroupHomePageUpdateRequestDto groupHomePageUpdateRequestDto) {
+		group.putHomePage(
+				groupHomePageUpdateRequestDto.getPreSignedLogoImageUrl(),
+				groupHomePageUpdateRequestDto.getContent(),
+				groupHomePageUpdateRequestDto.getEmail(),
+				groupHomePageUpdateRequestDto.getGroupSiteUrl()
 		);
 		groupRepository.save(group);
 	}

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -37,12 +37,14 @@ public class GroupCommandService {
 			throw ExceptionStatus.ALREADY_EXIST_GROUP_NAME.toServiceException();
 		}
 		LocalDateTime now = LocalDateTime.now();
+		String imageUrl = imageService.getImageUrl(
+				groupCreateRequestDto.getPreSignedLogoImageUrl());
 		Group group = Group.createGroup(
 				now,
 				member,
 				groupCreateRequestDto.getName(),
 				groupCreateRequestDto.getSummary(),
-				imageService.findImageUrl(groupCreateRequestDto.getPreSignedLogoImageUrl())
+				imageUrl
 		);
 		groupRepository.save(group);
 		GroupRegistration groupRegistration = GroupRegistration.of(

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -65,6 +65,9 @@ public class GroupCommandService {
 	 */
 	public void updateGroupAvatar(Group group,
 			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
+		if (groupRepository.findByName(groupAvatarUpdateRequestDto.getName()).isPresent()) {
+			throw ExceptionStatus.ALREADY_EXIST_GROUP_NAME.toServiceException();
+		}
 		group.updateAvatar(
 				groupAvatarUpdateRequestDto.getName(),
 				groupAvatarUpdateRequestDto.getPreSignedAvatarImageUrl()
@@ -105,7 +108,8 @@ public class GroupCommandService {
 				GroupRegistration.of(
 						member,
 						group,
-						GroupRole.COMMON
+						GroupRole.COMMON,
+						null
 				)
 		);
 	}

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -139,4 +139,28 @@ public class GroupCommandService {
 		groupRegistration.appointAdmin();
 		groupRegistrationRepository.save(groupRegistration);
 	}
+
+	/**
+	 * 그룹 소유자 임명
+	 *
+	 * @param group        그룹
+	 * @param targetMember 소유자로 임명할 멤버
+	 */
+	public void appointGroupOwner(Group group, Member targetMember) {
+		GroupRegistration ownerRegistration = groupRegistrationRepository.findByRole(
+						GroupRole.OWNER)
+				.orElseThrow(ExceptionStatus.NOT_GROUP_OWNER::toServiceException);
+		GroupRegistration targetRegistration = groupRegistrationRepository
+				.findByGroupIdAndMemberId(group.getId(), targetMember.getId())
+				.orElseThrow(ExceptionStatus.NOT_GROUP_MEMBER::toServiceException);
+		if (targetRegistration.getRole() == GroupRole.OWNER) {
+			throw ExceptionStatus.ALREADY_GROUP_OWNER.toServiceException();
+		}
+		ownerRegistration.appointAdmin();
+		targetRegistration.appointOwner();
+		groupRegistrationRepository.save(ownerRegistration);
+		groupRegistrationRepository.save(targetRegistration);
+		group.setOwnerMember(targetMember);
+		groupRepository.save(group);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -8,6 +8,7 @@ import org.unisphere.unisphere.annotation.Logging;
 import org.unisphere.unisphere.exception.ExceptionStatus;
 import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
+import org.unisphere.unisphere.group.dto.request.GroupAvatarUpdateRequestDto;
 import org.unisphere.unisphere.group.dto.request.GroupCreateRequestDto;
 import org.unisphere.unisphere.group.infrastructure.GroupRegistrationRepository;
 import org.unisphere.unisphere.group.infrastructure.GroupRepository;
@@ -41,7 +42,7 @@ public class GroupCommandService {
 				member,
 				groupCreateRequestDto.getName(),
 				groupCreateRequestDto.getSummary(),
-				imageService.getImageUrl(groupCreateRequestDto.getPreSignedLogoImageUrl())
+				imageService.findImageUrl(groupCreateRequestDto.getPreSignedLogoImageUrl())
 		);
 		groupRepository.save(group);
 		GroupRegistration groupRegistration = GroupRegistration.of(
@@ -50,5 +51,14 @@ public class GroupCommandService {
 				group
 		);
 		groupRegistrationRepository.save(groupRegistration);
+	}
+
+	public void updateGroupAvatar(Group group,
+			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
+		group.updateAvatar(
+				groupAvatarUpdateRequestDto.getName(),
+				groupAvatarUpdateRequestDto.getPreSignedAvatarImageUrl()
+		);
+		groupRepository.save(group);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -121,4 +121,22 @@ public class GroupCommandService {
 		groupRegistration.approve();
 		groupRegistrationRepository.save(groupRegistration);
 	}
+
+	/**
+	 * 그룹 관리자 임명
+	 *
+	 * @param group        그룹
+	 * @param targetMember 관리자로 임명할 멤버
+	 */
+	public void appointGroupAdmin(Group group, Member targetMember) {
+		GroupRegistration groupRegistration = groupRegistrationRepository
+				.findByGroupIdAndMemberId(group.getId(), targetMember.getId())
+				.orElseThrow(ExceptionStatus.NOT_GROUP_MEMBER::toServiceException);
+		if (groupRegistration.getRole() == GroupRole.ADMIN
+				|| groupRegistration.getRole() == GroupRole.OWNER) {
+			throw ExceptionStatus.ALREADY_GROUP_ADMIN.toServiceException();
+		}
+		groupRegistration.appointAdmin();
+		groupRegistrationRepository.save(groupRegistration);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupCommandService.java
@@ -163,4 +163,13 @@ public class GroupCommandService {
 		group.setOwnerMember(targetMember);
 		groupRepository.save(group);
 	}
+
+	/**
+	 * 그룹 삭제
+	 *
+	 * @param group 삭제할 그룹
+	 */
+	public void deleteGroup(Group group) {
+		groupRepository.delete(group);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -9,11 +9,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.unisphere.unisphere.annotation.Logging;
+import org.unisphere.unisphere.exception.ExceptionStatus;
 import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
 import org.unisphere.unisphere.group.dto.GroupPreviewDto;
+import org.unisphere.unisphere.group.dto.request.GroupAvatarUpdateRequestDto;
 import org.unisphere.unisphere.group.dto.request.GroupCreateRequestDto;
+import org.unisphere.unisphere.group.dto.response.GroupAvatarResponseDto;
 import org.unisphere.unisphere.group.dto.response.GroupListResponseDto;
+import org.unisphere.unisphere.image.service.ImageService;
 import org.unisphere.unisphere.log.LogLevel;
 import org.unisphere.unisphere.mapper.GroupMapper;
 import org.unisphere.unisphere.member.domain.Member;
@@ -28,10 +32,11 @@ public class GroupFacadeService {
 	private final GroupCommandService groupCommandService;
 	private final MemberQueryService memberQueryService;
 	private final GroupMapper groupMapper;
+	private ImageService imageService;
 
 	@Transactional(readOnly = true)
 	public GroupListResponseDto getAllGroups(Pageable pageable) {
-		Page<Group> groups = groupQueryService.getAllGroups(pageable);
+		Page<Group> groups = groupQueryService.findAllGroups(pageable);
 		List<GroupPreviewDto> groupPreviewDtos = groups.stream()
 				.sorted(Comparator.comparing(Group::getName))
 				.map(groupMapper::toGroupPreviewDto)
@@ -42,7 +47,7 @@ public class GroupFacadeService {
 	@Transactional(readOnly = true)
 	public GroupListResponseDto getMyGroups(Long memberId, Pageable pageable) {
 		Member member = memberQueryService.getMember(memberId);
-		Page<GroupRegistration> groupRegistrations = groupQueryService.getMemberGroups(member,
+		Page<GroupRegistration> groupRegistrations = groupQueryService.findMemberGroups(member,
 				pageable);
 		List<GroupPreviewDto> groupPreviewDtos = groupRegistrations.stream()
 				.sorted(Comparator.comparing(
@@ -54,9 +59,47 @@ public class GroupFacadeService {
 				groupRegistrations.getTotalElements());
 	}
 
+	@Transactional(readOnly = true)
+	public GroupListResponseDto getMemberGroups(Long memberId, Pageable pageable) {
+		Member member = memberQueryService.getMember(memberId);
+		Page<GroupRegistration> groupRegistrations = groupQueryService.findMemberGroups(member,
+				pageable);
+		List<GroupPreviewDto> groupPreviewDtos = groupRegistrations.stream()
+				.sorted(Comparator.comparing(
+						groupRegistration -> groupRegistration.getGroup().getName()))
+				.map(groupRegistration -> groupMapper.toGroupPreviewDto(
+						groupRegistration.getGroup()))
+				.collect(Collectors.toList());
+		return groupMapper.toGroupListResponseDto(groupPreviewDtos,
+				groupRegistrations.getTotalElements());
+	}
+
+	@Transactional(readOnly = true)
+	public GroupAvatarResponseDto getGroupAvatar(Long groupId) {
+		Group group = groupQueryService.getGroup(groupId);
+		return groupMapper.toGroupAvatarResponseDto(group, group.getAvatarImageUrl());
+	}
+
 	@Transactional
 	public void createGroup(Long memberId, GroupCreateRequestDto groupCreateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
+		if (groupQueryService.findGroupByName(groupCreateRequestDto.getName()).isPresent()) {
+			throw ExceptionStatus.ALREADY_EXIST_GROUP_NAME.toServiceException();
+		}
 		groupCommandService.createGroup(member, groupCreateRequestDto);
+	}
+
+	@Transactional
+	public GroupAvatarResponseDto updateGroupAvatar(Long memberId, Long groupId,
+			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!group.isOwner(member)) {
+			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
+		}
+		String imageUrl = imageService.findImageUrl(
+				groupAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
+		groupCommandService.updateGroupAvatar(group, groupAvatarUpdateRequestDto);
+		return groupMapper.toGroupAvatarResponseDto(group, imageUrl);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -199,4 +199,14 @@ public class GroupFacadeService {
 		Member targetMember = memberQueryService.getMember(targetMemberId);
 		groupCommandService.appointGroupOwner(group, targetMember);
 	}
+
+	@Transactional
+	public void deleteGroup(Long memberId, Long groupId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!group.isOwner(member)) {
+			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
+		}
+		groupCommandService.deleteGroup(group);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -129,8 +129,8 @@ public class GroupFacadeService {
 			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isOwner(member)) {
-			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
+		if (!group.isGroupAdmin(member)) {
+			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		String imageUrl = imageService.getImageUrl(
 				groupAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
@@ -146,8 +146,8 @@ public class GroupFacadeService {
 			GroupHomePageUpdateRequestDto groupHomePageUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isOwner(member)) {
-			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
+		if (!group.isGroupAdmin(member)) {
+			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		String logoImageUrl = imageService.getImageUrl(
 				groupHomePageUpdateRequestDto.getPreSignedLogoImageUrl());
@@ -155,5 +155,26 @@ public class GroupFacadeService {
 				group.getAvatarImageUrl());
 		groupCommandService.putGroupHomePage(group, groupHomePageUpdateRequestDto);
 		return groupMapper.toGroupHomePageResponseDto(group, avatarImageUrl, logoImageUrl);
+	}
+
+	@Transactional
+	public void requestRegisterGroup(Long memberId, Long groupId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (group.isGroupMember(member)) {
+			throw ExceptionStatus.ALREADY_GROUP_MEMBER.toServiceException();
+		}
+		groupCommandService.requestRegisterGroup(member, group);
+	}
+
+	@Transactional
+	public void approveGroupRegister(Long memberId, Long groupId, Long targetMemberId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!group.isGroupAdmin(member)) {
+			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
+		}
+		Member targetMember = memberQueryService.getMember(targetMemberId);
+		groupCommandService.approveGroupRegister(group, targetMember);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -66,7 +66,9 @@ public class GroupFacadeService {
 
 	@Transactional(readOnly = true)
 	public GroupListResponseDto getMemberGroups(Long memberId, Pageable pageable) {
-		Page<GroupRegistration> groupRegistrations = groupQueryService.findMemberGroups(memberId,
+		Member member = memberQueryService.getMember(memberId);
+		Page<GroupRegistration> groupRegistrations = groupQueryService.findMemberGroups(
+				member.getId(),
 				pageable);
 		List<GroupPreviewDto> groupPreviewDtos = groupRegistrations.stream()
 				.sorted(Comparator.comparing(
@@ -81,7 +83,9 @@ public class GroupFacadeService {
 
 	@Transactional(readOnly = true)
 	public GroupMemberListResponseDto getGroupMembers(Long groupId, Pageable pageable) {
-		Page<GroupRegistration> groupRegistrations = groupQueryService.findGroupMembers(groupId,
+		Group group = groupQueryService.getGroup(groupId);
+		Page<GroupRegistration> groupRegistrations = groupQueryService.findGroupMembers(
+				group.getId(),
 				pageable);
 		List<GroupMemberDto> groupMemberDtos = groupRegistrations.stream()
 				.sorted(Comparator.comparing(

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -161,73 +161,43 @@ public class GroupFacadeService {
 	public void requestRegisterGroup(Long memberId, Long groupId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (groupQueryService.findGroupMembers(group.getId()).contains(member)) {
-			throw ExceptionStatus.ALREADY_GROUP_MEMBER.toServiceException();
-		}
-		groupCommandService.requestRegisterGroup(member, group);
+		groupCommandService.requestRegisterGroup(group, member);
 	}
 
 	@Transactional
 	public void approveGroupRegister(Long memberId, Long groupId, Long targetMemberId) {
-		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
-			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
-		}
-		Member targetMember = memberQueryService.getMember(targetMemberId);
-		groupCommandService.approveGroupRegister(group, targetMember);
+		groupCommandService.approveGroupRegister(group, memberId, targetMemberId);
 	}
 
 	@Transactional
 	public void appointGroupAdmin(Long memberId, Long groupId, Long targetMemberId) {
-		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupOwner(member)) {
-			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
-		}
-		Member targetMember = memberQueryService.getMember(targetMemberId);
-		groupCommandService.appointGroupAdmin(group, targetMember);
+		groupCommandService.appointGroupAdmin(group, memberId, targetMemberId);
 	}
 
 	@Transactional
 	public void appointGroupOwner(Long memberId, Long groupId, Long targetMemberId) {
-		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupOwner(member)) {
-			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
-		}
-		Member targetMember = memberQueryService.getMember(targetMemberId);
-		groupCommandService.appointGroupOwner(group, targetMember);
+		groupCommandService.appointGroupOwner(group, memberId, targetMemberId);
 	}
 
 	@Transactional
 	public void deleteGroup(Long memberId, Long groupId) {
-		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupOwner(member)) {
-			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
-		}
-		groupCommandService.deleteGroup(group);
+		Member member = memberQueryService.getMember(memberId);
+		groupCommandService.deleteGroup(group, member);
 	}
 
 	@Transactional
 	public void unregisterGroup(Long memberId, Long groupId) {
-		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!groupQueryService.findGroupMembers(group.getId()).contains(member)) {
-			throw ExceptionStatus.NOT_GROUP_MEMBER.toServiceException();
-		}
-		groupCommandService.unregisterGroup(member, group);
+		groupCommandService.unregisterGroup(group, memberId);
 	}
 
 	@Transactional
 	public void kickMemberFromGroup(Long memberId, Long groupId, Long targetMemberId) {
-		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
-			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
-		}
-		Member targetMember = memberQueryService.getMember(targetMemberId);
-		groupCommandService.kickMemberFromGroup(member, group, targetMember);
+		groupCommandService.kickMemberFromGroup(group, memberId, targetMemberId);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -32,7 +32,7 @@ public class GroupFacadeService {
 	private final GroupCommandService groupCommandService;
 	private final MemberQueryService memberQueryService;
 	private final GroupMapper groupMapper;
-	private ImageService imageService;
+	private final ImageService imageService;
 
 	@Transactional(readOnly = true)
 	public GroupListResponseDto getAllGroups(Pageable pageable) {
@@ -97,7 +97,7 @@ public class GroupFacadeService {
 		if (!group.isOwner(member)) {
 			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
 		}
-		String imageUrl = imageService.findImageUrl(
+		String imageUrl = imageService.getImageUrl(
 				groupAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
 		groupCommandService.updateGroupAvatar(group, groupAvatarUpdateRequestDto);
 		return groupMapper.toGroupAvatarResponseDto(group, imageUrl);

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -188,4 +188,15 @@ public class GroupFacadeService {
 		Member targetMember = memberQueryService.getMember(targetMemberId);
 		groupCommandService.appointGroupAdmin(group, targetMember);
 	}
+
+	@Transactional
+	public void appointGroupOwner(Long memberId, Long groupId, Long targetMemberId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!group.isOwner(member)) {
+			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
+		}
+		Member targetMember = memberQueryService.getMember(targetMemberId);
+		groupCommandService.appointGroupOwner(group, targetMember);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -122,9 +122,6 @@ public class GroupFacadeService {
 	@Transactional
 	public void createGroup(Long memberId, GroupCreateRequestDto groupCreateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
-		if (groupQueryService.findGroupByName(groupCreateRequestDto.getName()).isPresent()) {
-			throw ExceptionStatus.ALREADY_EXIST_GROUP_NAME.toServiceException();
-		}
 		groupCommandService.createGroup(member, groupCreateRequestDto);
 	}
 
@@ -133,7 +130,7 @@ public class GroupFacadeService {
 			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
+		if (!groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
 			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		String imageUrl = imageService.getImageUrl(
@@ -150,7 +147,7 @@ public class GroupFacadeService {
 			GroupHomePageUpdateRequestDto groupHomePageUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
+		if (!groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
 			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		String logoImageUrl = imageService.getImageUrl(

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -129,7 +129,7 @@ public class GroupFacadeService {
 			GroupAvatarUpdateRequestDto groupAvatarUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupAdmin(member)) {
+		if (groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
 			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		String imageUrl = imageService.getImageUrl(
@@ -146,7 +146,7 @@ public class GroupFacadeService {
 			GroupHomePageUpdateRequestDto groupHomePageUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupAdmin(member)) {
+		if (groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
 			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		String logoImageUrl = imageService.getImageUrl(
@@ -161,7 +161,7 @@ public class GroupFacadeService {
 	public void requestRegisterGroup(Long memberId, Long groupId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (group.isGroupMember(member)) {
+		if (groupQueryService.findGroupMembers(group.getId()).contains(member)) {
 			throw ExceptionStatus.ALREADY_GROUP_MEMBER.toServiceException();
 		}
 		groupCommandService.requestRegisterGroup(member, group);
@@ -171,7 +171,7 @@ public class GroupFacadeService {
 	public void approveGroupRegister(Long memberId, Long groupId, Long targetMemberId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupAdmin(member)) {
+		if (!groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
 			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
 		}
 		Member targetMember = memberQueryService.getMember(targetMemberId);
@@ -182,7 +182,7 @@ public class GroupFacadeService {
 	public void appointGroupAdmin(Long memberId, Long groupId, Long targetMemberId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isOwner(member)) {
+		if (!group.isGroupOwner(member)) {
 			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
 		}
 		Member targetMember = memberQueryService.getMember(targetMemberId);
@@ -193,7 +193,7 @@ public class GroupFacadeService {
 	public void appointGroupOwner(Long memberId, Long groupId, Long targetMemberId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isOwner(member)) {
+		if (!group.isGroupOwner(member)) {
 			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
 		}
 		Member targetMember = memberQueryService.getMember(targetMemberId);
@@ -204,7 +204,7 @@ public class GroupFacadeService {
 	public void deleteGroup(Long memberId, Long groupId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isOwner(member)) {
+		if (!group.isGroupOwner(member)) {
 			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
 		}
 		groupCommandService.deleteGroup(group);
@@ -214,9 +214,20 @@ public class GroupFacadeService {
 	public void unregisterGroup(Long memberId, Long groupId) {
 		Member member = memberQueryService.getMember(memberId);
 		Group group = groupQueryService.getGroup(groupId);
-		if (!group.isGroupMember(member)) {
+		if (!groupQueryService.findGroupMembers(group.getId()).contains(member)) {
 			throw ExceptionStatus.NOT_GROUP_MEMBER.toServiceException();
 		}
 		groupCommandService.unregisterGroup(member, group);
+	}
+
+	@Transactional
+	public void kickMemberFromGroup(Long memberId, Long groupId, Long targetMemberId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!groupQueryService.findGroupAdmins(group.getId()).contains(member)) {
+			throw ExceptionStatus.NOT_GROUP_ADMIN.toServiceException();
+		}
+		Member targetMember = memberQueryService.getMember(targetMemberId);
+		groupCommandService.kickMemberFromGroup(member, group, targetMember);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -209,4 +209,14 @@ public class GroupFacadeService {
 		}
 		groupCommandService.deleteGroup(group);
 	}
+
+	@Transactional
+	public void unregisterGroup(Long memberId, Long groupId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!group.isGroupMember(member)) {
+			throw ExceptionStatus.NOT_GROUP_MEMBER.toServiceException();
+		}
+		groupCommandService.unregisterGroup(member, group);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupFacadeService.java
@@ -177,4 +177,15 @@ public class GroupFacadeService {
 		Member targetMember = memberQueryService.getMember(targetMemberId);
 		groupCommandService.approveGroupRegister(group, targetMember);
 	}
+
+	@Transactional
+	public void appointGroupAdmin(Long memberId, Long groupId, Long targetMemberId) {
+		Member member = memberQueryService.getMember(memberId);
+		Group group = groupQueryService.getGroup(groupId);
+		if (!group.isOwner(member)) {
+			throw ExceptionStatus.NOT_GROUP_OWNER.toServiceException();
+		}
+		Member targetMember = memberQueryService.getMember(targetMemberId);
+		groupCommandService.appointGroupAdmin(group, targetMember);
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupQueryService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupQueryService.java
@@ -34,13 +34,25 @@ public class GroupQueryService {
 	/**
 	 * 회원이 속한 그룹 정보 조회
 	 *
-	 * @param member   회원
+	 * @param memberId 회원 ID
 	 * @param pageable 페이징 정보
 	 * @return 회원이 속한 그룹 정보 (Page)
 	 */
-	public Page<GroupRegistration> findMemberGroups(Member member, Pageable pageable) {
+	public Page<GroupRegistration> findMemberGroups(Long memberId, Pageable pageable) {
 		return groupRegistrationRepository.findAllByMemberId(
-				member.getId(), pageable);
+				memberId, pageable);
+	}
+
+	/**
+	 * 그룹에 속한 회원 정보 조회
+	 *
+	 * @param groupId  그룹 ID
+	 * @param pageable 페이징 정보
+	 * @return 그룹에 속한 회원 정보 (Page)
+	 */
+	public Page<GroupRegistration> findGroupMembers(Long groupId, Pageable pageable) {
+		return groupRegistrationRepository.findAllByGroupId(
+				groupId, pageable);
 	}
 
 	/**

--- a/src/main/java/org/unisphere/unisphere/group/service/GroupQueryService.java
+++ b/src/main/java/org/unisphere/unisphere/group/service/GroupQueryService.java
@@ -1,10 +1,12 @@
 package org.unisphere.unisphere.group.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.unisphere.unisphere.annotation.Logging;
+import org.unisphere.unisphere.exception.ExceptionStatus;
 import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
 import org.unisphere.unisphere.group.infrastructure.GroupRegistrationRepository;
@@ -25,7 +27,7 @@ public class GroupQueryService {
 	 * @param pageable 페이징 정보
 	 * @return 전체 그룹 정보 (Page)
 	 */
-	public Page<Group> getAllGroups(Pageable pageable) {
+	public Page<Group> findAllGroups(Pageable pageable) {
 		return groupRepository.findAll(pageable);
 	}
 
@@ -36,8 +38,29 @@ public class GroupQueryService {
 	 * @param pageable 페이징 정보
 	 * @return 회원이 속한 그룹 정보 (Page)
 	 */
-	public Page<GroupRegistration> getMemberGroups(Member member, Pageable pageable) {
+	public Page<GroupRegistration> findMemberGroups(Member member, Pageable pageable) {
 		return groupRegistrationRepository.findAllByMemberId(
 				member.getId(), pageable);
+	}
+
+	/**
+	 * 그룹 이름으로 Group 조회
+	 *
+	 * @param name 그룹 이름
+	 * @return 조회된 Group 객체
+	 */
+	public Optional<Group> findGroupByName(String name) {
+		return groupRepository.findByName(name);
+	}
+
+	/**
+	 * 그룹 ID로 Group 정보를 가져온다.
+	 *
+	 * @param groupId 그룹 ID
+	 * @return Group 객체
+	 */
+	public Group getGroup(Long groupId) {
+		Optional<Group> group = groupRepository.findById(groupId);
+		return group.orElseThrow(ExceptionStatus.NOT_FOUND_GROUP::toServiceException);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/group/validation/AvatarUpdateValidation.java
+++ b/src/main/java/org/unisphere/unisphere/group/validation/AvatarUpdateValidation.java
@@ -1,0 +1,20 @@
+package org.unisphere.unisphere.group.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AvatarUpdateValidator.class)
+public @interface AvatarUpdateValidation {
+
+	String message() default "AvatarUpdateValidation";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/unisphere/unisphere/group/validation/AvatarUpdateValidator.java
+++ b/src/main/java/org/unisphere/unisphere/group/validation/AvatarUpdateValidator.java
@@ -1,0 +1,64 @@
+package org.unisphere.unisphere.group.validation;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.unisphere.unisphere.group.dto.request.GroupAvatarUpdateRequestDto;
+
+public class AvatarUpdateValidator implements
+		ConstraintValidator<AvatarUpdateValidation, GroupAvatarUpdateRequestDto> {
+
+	private static final String GROUP_NAME_REGEX = "^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$";
+	private static final Pattern GROUP_NAME_PATTERN = Pattern.compile(GROUP_NAME_REGEX);
+	private static final int GROUP_NAME_MIN_LENGTH = 2;
+	private static final int GROUP_NAME_MAX_LENGTH = 16;
+	private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+			"jpeg", "jpg", "png");
+
+	private boolean validateGroupName(GroupAvatarUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getName() == null || value.getName().isEmpty()) {
+			return true;
+		}
+
+		if (value.getName().length() < GROUP_NAME_MIN_LENGTH
+				|| value.getName().length() > GROUP_NAME_MAX_LENGTH) {
+			context.buildConstraintViolationWithTemplate("그룹명은 " + GROUP_NAME_MIN_LENGTH
+							+ "자 이상 " + GROUP_NAME_MAX_LENGTH + "자 이하로 입력해주세요.")
+					.addConstraintViolation();
+			return false;
+		}
+
+		if (!GROUP_NAME_PATTERN.matcher(value.getName()).matches()) {
+			context.buildConstraintViolationWithTemplate("그룹명은 한글, 영문, 숫자만 입력 가능합니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateAvatarImageUrl(GroupAvatarUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getPreSignedAvatarImageUrl() == null
+				|| value.getPreSignedAvatarImageUrl().isEmpty()) {
+			return true;
+		}
+
+		String[] split = value.getPreSignedAvatarImageUrl().split("\\.");
+		String imageType = split[split.length - 1];
+		if (!ALLOWED_IMAGE_TYPES.contains(imageType)) {
+			context.buildConstraintViolationWithTemplate("이미지는 " + ALLOWED_IMAGE_TYPES
+							+ " 형식만 지원합니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean isValid(GroupAvatarUpdateRequestDto value, ConstraintValidatorContext context) {
+		return validateGroupName(value, context) && validateAvatarImageUrl(value, context);
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/group/validation/GroupHomePageUpdateValidation.java
+++ b/src/main/java/org/unisphere/unisphere/group/validation/GroupHomePageUpdateValidation.java
@@ -1,0 +1,20 @@
+package org.unisphere.unisphere.group.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = GroupHomePageUpdateValidator.class)
+public @interface GroupHomePageUpdateValidation {
+
+	String message() default "GroupHomePageUpdateValidation";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/unisphere/unisphere/group/validation/GroupHomePageUpdateValidator.java
+++ b/src/main/java/org/unisphere/unisphere/group/validation/GroupHomePageUpdateValidator.java
@@ -1,0 +1,105 @@
+package org.unisphere.unisphere.group.validation;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.unisphere.unisphere.group.dto.request.GroupHomePageUpdateRequestDto;
+
+public class GroupHomePageUpdateValidator implements
+		ConstraintValidator<GroupHomePageUpdateValidation, GroupHomePageUpdateRequestDto> {
+
+	private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+			"jpeg", "jpg", "png");
+
+	private static final int MAX_CONTENT_LENGTH = 1024;
+	private static final String EMAIL_REGEX = "^[^@]+@[a-zA-Z]+\\.([a-zA-Z]+)$";
+	private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
+	private static final int MAX_EMAIL_LENGTH = 64;
+	private static final String GROUP_SITE_URL_REGEX = "^(http|https)://[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+(/[a-zA-Z0-9-]+)*$";
+	private static final Pattern GROUP_SITE_URL_PATTERN = Pattern.compile(GROUP_SITE_URL_REGEX);
+	private static final int MAX_GROUP_SITE_URL_LENGTH = 64;
+
+	private boolean validatePreSignedLogoImageUrl(GroupHomePageUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getPreSignedLogoImageUrl() == null
+				|| value.getPreSignedLogoImageUrl().isEmpty()) {
+			return true;
+		}
+
+		String[] split = value.getPreSignedLogoImageUrl().split("\\.");
+		String imageType = split[split.length - 1];
+		if (!ALLOWED_IMAGE_TYPES.contains(imageType)) {
+			context.buildConstraintViolationWithTemplate("이미지는 " + ALLOWED_IMAGE_TYPES
+							+ " 형식만 지원합니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateContent(GroupHomePageUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getContent() == null || value.getContent().isEmpty()) {
+			return true;
+		}
+
+		if (value.getContent().length() > MAX_CONTENT_LENGTH) {
+			context.buildConstraintViolationWithTemplate("단체 소개 설명은 " + MAX_CONTENT_LENGTH
+							+ "자 이하로 입력해주세요.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateEmail(GroupHomePageUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getEmail() == null || value.getEmail().isEmpty()) {
+			return true;
+		}
+
+		if (value.getEmail().length() > MAX_EMAIL_LENGTH) {
+			context.buildConstraintViolationWithTemplate("이메일 주소는 " + MAX_EMAIL_LENGTH
+							+ "자 이하로 입력해주세요.")
+					.addConstraintViolation();
+			return false;
+		}
+
+		if (!EMAIL_PATTERN.matcher(value.getEmail()).matches()) {
+			context.buildConstraintViolationWithTemplate("이메일 형식이 올바르지 않습니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateGroupSiteUrl(GroupHomePageUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		if (value.getGroupSiteUrl() == null || value.getGroupSiteUrl().isEmpty()) {
+			return true;
+		}
+
+		if (value.getGroupSiteUrl().length() > MAX_GROUP_SITE_URL_LENGTH) {
+			context.buildConstraintViolationWithTemplate("홈페이지 주소는 " + MAX_GROUP_SITE_URL_LENGTH
+							+ "자 이하로 입력해주세요.")
+					.addConstraintViolation();
+			return false;
+		}
+
+		if (!GROUP_SITE_URL_PATTERN.matcher(value.getGroupSiteUrl()).matches()) {
+			context.buildConstraintViolationWithTemplate("홈페이지 주소 형식이 올바르지 않습니다.")
+					.addConstraintViolation();
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean isValid(GroupHomePageUpdateRequestDto value,
+			ConstraintValidatorContext context) {
+		return validatePreSignedLogoImageUrl(value, context) && validateContent(value, context)
+				&& validateEmail(value, context) && validateGroupSiteUrl(value, context);
+	}
+}

--- a/src/main/java/org/unisphere/unisphere/image/domain/AwsS3Manager.java
+++ b/src/main/java/org/unisphere/unisphere/image/domain/AwsS3Manager.java
@@ -33,9 +33,9 @@ public class AwsS3Manager {
 		}
 	}
 
-	public String findObjectUrl(String key) {
+	public String getObjectUrl(String key) {
 		if (!doesObjectExist(key)) {
-			return null;
+			throw ExceptionStatus.NOT_FOUND_IMAGE.toDomainException();
 		}
 		return amazonS3Client.getUrl(bucketName, key).toString();
 	}

--- a/src/main/java/org/unisphere/unisphere/image/domain/AwsS3Manager.java
+++ b/src/main/java/org/unisphere/unisphere/image/domain/AwsS3Manager.java
@@ -33,9 +33,9 @@ public class AwsS3Manager {
 		}
 	}
 
-	public String getObjectUrl(String key) {
+	public String findObjectUrl(String key) {
 		if (!doesObjectExist(key)) {
-			throw ExceptionStatus.NOT_FOUND_IMAGE.toDomainException();
+			return null;
 		}
 		return amazonS3Client.getUrl(bucketName, key).toString();
 	}

--- a/src/main/java/org/unisphere/unisphere/image/domain/AwsS3Manager.java
+++ b/src/main/java/org/unisphere/unisphere/image/domain/AwsS3Manager.java
@@ -13,7 +13,7 @@ import org.unisphere.unisphere.log.LogLevel;
 
 @Component
 @Logging(level = LogLevel.DEBUG)
-public class AwsS3Manager {
+public class AwsS3Manager implements ObjectStorageManager {
 
 	private final String bucketName;
 	private final AmazonS3Client amazonS3Client;
@@ -25,6 +25,7 @@ public class AwsS3Manager {
 		this.bucketName = bucketName;
 	}
 
+	@Override
 	public void delete(String key) {
 		try {
 			amazonS3Client.deleteObject(bucketName, key);
@@ -33,6 +34,7 @@ public class AwsS3Manager {
 		}
 	}
 
+	@Override
 	public String getObjectUrl(String key) {
 		if (!doesObjectExist(key)) {
 			throw ExceptionStatus.NOT_FOUND_IMAGE.toDomainException();
@@ -40,11 +42,13 @@ public class AwsS3Manager {
 		return amazonS3Client.getUrl(bucketName, key).toString();
 	}
 
+	@Override
 	public String getPreSignedUrl(String objectKey) {
 		GeneratePresignedUrlRequest request = createPreSignedUrlRequest(objectKey);
 		return amazonS3Client.generatePresignedUrl(request).toString();
 	}
 
+	@Override
 	public boolean doesObjectExist(String objectKey) {
 		return amazonS3Client.doesObjectExist(bucketName, objectKey);
 	}

--- a/src/main/java/org/unisphere/unisphere/image/domain/ObjectStorageManager.java
+++ b/src/main/java/org/unisphere/unisphere/image/domain/ObjectStorageManager.java
@@ -1,0 +1,12 @@
+package org.unisphere.unisphere.image.domain;
+
+public interface ObjectStorageManager {
+
+	void delete(String key);
+
+	String getPreSignedUrl(String key);
+
+	String getObjectUrl(String key);
+
+	boolean doesObjectExist(String key);
+}

--- a/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
+++ b/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
@@ -43,11 +43,22 @@ public class ImageService {
 		return awsS3Manager.getPreSignedUrl(imageUrl);
 	}
 
+	public String getImageUrl(String imageUrl) {
+		if (Objects.isNull(imageUrl) || imageUrl.isBlank()) {
+			return null;
+		}
+		return awsS3Manager.getObjectUrl(imageUrl);
+	}
+
 	public String findImageUrl(String imageUrl) {
 		if (Objects.isNull(imageUrl) || imageUrl.isBlank()) {
 			return null;
 		}
-		return awsS3Manager.findObjectUrl(imageUrl);
+		try {
+			return awsS3Manager.getObjectUrl(imageUrl);
+		} catch (Exception e) {
+			return null;
+		}
 	}
 
 	private List<String> getValidDirNameList() {

--- a/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
+++ b/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.unisphere.unisphere.annotation.Logging;
-import org.unisphere.unisphere.image.domain.AwsS3Manager;
+import org.unisphere.unisphere.image.domain.ObjectStorageManager;
 import org.unisphere.unisphere.log.LogLevel;
 
 @Service
@@ -28,7 +28,7 @@ public class ImageService {
 	private String LOGO_IMAGE_DIR;
 
 	private static final List<String> validImageExtension = List.of(".jpg", ".jpeg", ".png");
-	private final AwsS3Manager awsS3Manager;
+	private final ObjectStorageManager objectStorageManager;
 
 
 	public String getPreSignedUrl(String imageUrl) {
@@ -40,14 +40,14 @@ public class ImageService {
 			throw new HttpClientErrorException(HttpStatus.BAD_REQUEST,
 					imageUrl + "은 유효하지 않은 파일 확장자입니다. (유효한 파일 확장자: " + validImageExtension + ")");
 		}
-		return awsS3Manager.getPreSignedUrl(imageUrl);
+		return objectStorageManager.getPreSignedUrl(imageUrl);
 	}
 
 	public String getImageUrl(String imageUrl) {
 		if (Objects.isNull(imageUrl) || imageUrl.isBlank()) {
 			return null;
 		}
-		return awsS3Manager.getObjectUrl(imageUrl);
+		return objectStorageManager.getObjectUrl(imageUrl);
 	}
 
 	public String findImageUrl(String imageUrl) {
@@ -55,7 +55,7 @@ public class ImageService {
 			return null;
 		}
 		try {
-			return awsS3Manager.getObjectUrl(imageUrl);
+			return objectStorageManager.getObjectUrl(imageUrl);
 		} catch (Exception e) {
 			return null;
 		}

--- a/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
+++ b/src/main/java/org/unisphere/unisphere/image/service/ImageService.java
@@ -43,11 +43,11 @@ public class ImageService {
 		return awsS3Manager.getPreSignedUrl(imageUrl);
 	}
 
-	public String getImageUrl(String imageUrl) {
+	public String findImageUrl(String imageUrl) {
 		if (Objects.isNull(imageUrl) || imageUrl.isBlank()) {
 			return null;
 		}
-		return awsS3Manager.getObjectUrl(imageUrl);
+		return awsS3Manager.findObjectUrl(imageUrl);
 	}
 
 	private List<String> getValidDirNameList() {

--- a/src/main/java/org/unisphere/unisphere/mapper/GroupMapper.java
+++ b/src/main/java/org/unisphere/unisphere/mapper/GroupMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.dto.GroupPreviewDto;
+import org.unisphere.unisphere.group.dto.response.GroupAvatarResponseDto;
 import org.unisphere.unisphere.group.dto.response.GroupListResponseDto;
 
 @Mapper(componentModel = "spring")
@@ -19,4 +20,7 @@ public interface GroupMapper {
 	@Mapping(source = "groupPreviewDtos", target = "groups")
 	GroupListResponseDto toGroupListResponseDto(List<GroupPreviewDto> groupPreviewDtos,
 			long totalElements);
+
+	@Mapping(source = "group.id", target = "groupId")
+	GroupAvatarResponseDto toGroupAvatarResponseDto(Group group, String avatarImageUrl);
 }

--- a/src/main/java/org/unisphere/unisphere/mapper/GroupMapper.java
+++ b/src/main/java/org/unisphere/unisphere/mapper/GroupMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapping;
 import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.dto.GroupPreviewDto;
 import org.unisphere.unisphere.group.dto.response.GroupAvatarResponseDto;
+import org.unisphere.unisphere.group.dto.response.GroupHomePageResponseDto;
 import org.unisphere.unisphere.group.dto.response.GroupListResponseDto;
 
 @Mapper(componentModel = "spring")
@@ -22,5 +23,12 @@ public interface GroupMapper {
 			long totalElements);
 
 	@Mapping(source = "group.id", target = "groupId")
+	@Mapping(source = "avatarImageUrl", target = "avatarImageUrl")
 	GroupAvatarResponseDto toGroupAvatarResponseDto(Group group, String avatarImageUrl);
+
+	@Mapping(source = "group.id", target = "groupId")
+	@Mapping(source = "avatarImageUrl", target = "avatarImageUrl")
+	@Mapping(source = "logoImageUrl", target = "logoImageUrl")
+	GroupHomePageResponseDto toGroupHomePageResponseDto(Group group, String avatarImageUrl,
+			String logoImageUrl);
 }

--- a/src/main/java/org/unisphere/unisphere/mapper/GroupMapper.java
+++ b/src/main/java/org/unisphere/unisphere/mapper/GroupMapper.java
@@ -3,11 +3,16 @@ package org.unisphere.unisphere.mapper;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.unisphere.unisphere.auth.domain.MemberRole;
 import org.unisphere.unisphere.group.domain.Group;
+import org.unisphere.unisphere.group.domain.GroupRole;
+import org.unisphere.unisphere.group.dto.GroupMemberDto;
 import org.unisphere.unisphere.group.dto.GroupPreviewDto;
 import org.unisphere.unisphere.group.dto.response.GroupAvatarResponseDto;
 import org.unisphere.unisphere.group.dto.response.GroupHomePageResponseDto;
 import org.unisphere.unisphere.group.dto.response.GroupListResponseDto;
+import org.unisphere.unisphere.group.dto.response.GroupMemberListResponseDto;
+import org.unisphere.unisphere.member.domain.Member;
 
 @Mapper(componentModel = "spring")
 public interface GroupMapper {
@@ -15,7 +20,8 @@ public interface GroupMapper {
 	GroupMapper INSTANCE = org.mapstruct.factory.Mappers.getMapper(GroupMapper.class);
 
 	@Mapping(source = "group.id", target = "groupId")
-	GroupPreviewDto toGroupPreviewDto(Group group);
+	@Mapping(source = "logoImageUrl", target = "logoImageUrl")
+	GroupPreviewDto toGroupPreviewDto(Group group, String logoImageUrl);
 
 	@Mapping(source = "totalElements", target = "totalGroupCount")
 	@Mapping(source = "groupPreviewDtos", target = "groups")
@@ -31,4 +37,14 @@ public interface GroupMapper {
 	@Mapping(source = "logoImageUrl", target = "logoImageUrl")
 	GroupHomePageResponseDto toGroupHomePageResponseDto(Group group, String avatarImageUrl,
 			String logoImageUrl);
+
+	@Mapping(source = "member.id", target = "memberId")
+	@Mapping(source = "avatarImageUrl", target = "avatarImageUrl")
+	@Mapping(source = "role", target = "role")
+	GroupMemberDto toGroupMemberDto(Member member, String avatarImageUrl, GroupRole role);
+
+	@Mapping(source = "totalElements", target = "totalMemberCount")
+	@Mapping(source = "groupMemberDtos", target = "groupMembers")
+	GroupMemberListResponseDto toGroupMemberListResponseDto(List<GroupMemberDto> groupMemberDtos,
+			long totalElements);
 }

--- a/src/main/java/org/unisphere/unisphere/mapper/MemberMapper.java
+++ b/src/main/java/org/unisphere/unisphere/mapper/MemberMapper.java
@@ -11,5 +11,6 @@ public interface MemberMapper {
 	MemberMapper INSTANCE = org.mapstruct.factory.Mappers.getMapper(MemberMapper.class);
 
 	@Mapping(source = "member.id", target = "memberId")
+	@Mapping(source = "avatarImageUrl", target = "avatarImageUrl")
 	MyAvatarResponseDto toMyAvatarResponseDto(Member member, String avatarImageUrl);
 }

--- a/src/main/java/org/unisphere/unisphere/mapper/MemberMapper.java
+++ b/src/main/java/org/unisphere/unisphere/mapper/MemberMapper.java
@@ -11,5 +11,5 @@ public interface MemberMapper {
 	MemberMapper INSTANCE = org.mapstruct.factory.Mappers.getMapper(MemberMapper.class);
 
 	@Mapping(source = "member.id", target = "memberId")
-	MyAvatarResponseDto toMyAvatarResponseDto(Member member);
+	MyAvatarResponseDto toMyAvatarResponseDto(Member member, String avatarImageUrl);
 }

--- a/src/main/java/org/unisphere/unisphere/member/domain/Member.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/Member.java
@@ -92,10 +92,10 @@ public class Member {
 	}
 
 	public void updateAvatar(String nickname, String preSignedAvatarImageUrl) {
-		if (nickname != null) {
+		if (nickname != null && !nickname.isEmpty()) {
 			this.nickname = nickname;
 		}
-		if (preSignedAvatarImageUrl != null) {
+		if (preSignedAvatarImageUrl != null && !preSignedAvatarImageUrl.isEmpty()) {
 			this.avatarImageUrl = preSignedAvatarImageUrl;
 		}
 	}

--- a/src/main/java/org/unisphere/unisphere/member/domain/Member.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/Member.java
@@ -14,7 +14,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,7 +21,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.unisphere.unisphere.article.domain.InterestedArticle;
 import org.unisphere.unisphere.auth.domain.MemberRole;
-import org.unisphere.unisphere.auth.domain.OauthType;
 import org.unisphere.unisphere.group.domain.Group;
 import org.unisphere.unisphere.group.domain.GroupRegistration;
 
@@ -56,14 +54,6 @@ public class Member {
 	private LocalDateTime deletedAt;
 
 	@ToString.Exclude
-	@OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-	private PasswordMember passwordMember;
-
-	@ToString.Exclude
-	@OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-	private SocialMember socialMember;
-
-	@ToString.Exclude
 	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<GroupRegistration> groupRegistrations = new ArrayList<>();
 
@@ -91,16 +81,14 @@ public class Member {
 		return Objects.equals(id, member.id);
 	}
 
-	public static Member createSocialMember(
-			String email, String nickname, LocalDateTime now, MemberRole role,
-			String oauthId, OauthType oauthType
+	public static Member of(
+			String email, String nickname, LocalDateTime now, MemberRole role
 	) {
 		Member member = new Member();
 		member.role = role;
 		member.email = email;
 		member.nickname = nickname;
 		member.createdAt = now;
-		member.socialMember = SocialMember.of(member, oauthId, oauthType);
 		member.isFirstLogin = true;
 		return member;
 	}

--- a/src/main/java/org/unisphere/unisphere/member/domain/Member.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/Member.java
@@ -77,6 +77,21 @@ public class Member {
 	@Transient
 	private boolean isFirstLogin = false;
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		Member member = (Member) o;
+
+		return getId().equals(member.getId()) || getEmail().equals(member.getEmail())
+				|| getNickname().equals(member.getNickname());
+	}
+
 	public static Member createSocialMember(
 			String email, String nickname, LocalDateTime now, MemberRole role,
 			String oauthId, OauthType oauthType

--- a/src/main/java/org/unisphere/unisphere/member/domain/Member.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/Member.java
@@ -3,6 +3,7 @@ package org.unisphere.unisphere.member.domain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -87,9 +88,7 @@ public class Member {
 		}
 
 		Member member = (Member) o;
-
-		return getId().equals(member.getId()) || getEmail().equals(member.getEmail())
-				|| getNickname().equals(member.getNickname());
+		return Objects.equals(id, member.id);
 	}
 
 	public static Member createSocialMember(

--- a/src/main/java/org/unisphere/unisphere/member/domain/PasswordMember.java
+++ b/src/main/java/org/unisphere/unisphere/member/domain/PasswordMember.java
@@ -33,4 +33,14 @@ public class PasswordMember {
 
 	@Column(nullable = false)
 	private String password;
+
+	public static PasswordMember of(
+			Member member, String username, String password
+	) {
+		PasswordMember passwordMember = new PasswordMember();
+		passwordMember.member = member;
+		passwordMember.username = username;
+		passwordMember.password = password;
+		return passwordMember;
+	}
 }

--- a/src/main/java/org/unisphere/unisphere/member/dto/response/MyAvatarResponseDto.java
+++ b/src/main/java/org/unisphere/unisphere/member/dto/response/MyAvatarResponseDto.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Getter
 @ToString
 @Builder
 @Schema(description = "내 아바타 정보")
+@FieldNameConstants
 public class MyAvatarResponseDto {
 
 	@Schema(description = "회원 ID", example = "1")

--- a/src/main/java/org/unisphere/unisphere/member/infrastructure/SocialMemberRepository.java
+++ b/src/main/java/org/unisphere/unisphere/member/infrastructure/SocialMemberRepository.java
@@ -1,0 +1,8 @@
+package org.unisphere.unisphere.member.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.unisphere.unisphere.member.domain.SocialMember;
+
+public interface SocialMemberRepository extends JpaRepository<SocialMember, Long> {
+
+}

--- a/src/main/java/org/unisphere/unisphere/member/service/MemberFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/member/service/MemberFacadeService.java
@@ -34,6 +34,9 @@ public class MemberFacadeService {
 		Member member = memberQueryService.getMember(memberId);
 		String imageUrl = imageService.getImageUrl(
 				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
+		if (imageUrl == null) {
+			imageUrl = imageService.findImageUrl(member.getAvatarImageUrl());
+		}
 		memberCommandService.updateAvatar(member, myAvatarUpdateRequestDto.getNickname(),
 				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
 		return memberMapper.toMyAvatarResponseDto(member, imageUrl);

--- a/src/main/java/org/unisphere/unisphere/member/service/MemberFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/member/service/MemberFacadeService.java
@@ -24,16 +24,18 @@ public class MemberFacadeService {
 	@Transactional(readOnly = true)
 	public MyAvatarResponseDto getMemberAvatar(Long memberId) {
 		Member member = memberQueryService.getMember(memberId);
-		return memberMapper.toMyAvatarResponseDto(member);
+		return memberMapper.toMyAvatarResponseDto(member,
+				imageService.findImageUrl(member.getAvatarImageUrl()));
 	}
 
 	@Transactional
 	public MyAvatarResponseDto updateMemberAvatar(Long memberId,
 			MyAvatarUpdateRequestDto myAvatarUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
-		String imageUrl = imageService.getImageUrl(
+		String imageUrl = imageService.findImageUrl(
 				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
-		memberCommandService.updateAvatar(member, myAvatarUpdateRequestDto.getNickname(), imageUrl);
-		return memberMapper.toMyAvatarResponseDto(member);
+		memberCommandService.updateAvatar(member, myAvatarUpdateRequestDto.getNickname(),
+				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
+		return memberMapper.toMyAvatarResponseDto(member, imageUrl);
 	}
 }

--- a/src/main/java/org/unisphere/unisphere/member/service/MemberFacadeService.java
+++ b/src/main/java/org/unisphere/unisphere/member/service/MemberFacadeService.java
@@ -32,7 +32,7 @@ public class MemberFacadeService {
 	public MyAvatarResponseDto updateMemberAvatar(Long memberId,
 			MyAvatarUpdateRequestDto myAvatarUpdateRequestDto) {
 		Member member = memberQueryService.getMember(memberId);
-		String imageUrl = imageService.findImageUrl(
+		String imageUrl = imageService.getImageUrl(
 				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());
 		memberCommandService.updateAvatar(member, myAvatarUpdateRequestDto.getNickname(),
 				myAvatarUpdateRequestDto.getPreSignedAvatarImageUrl());

--- a/src/test/java/org/unisphere/unisphere/group/GroupCUDE2ETest.java
+++ b/src/test/java/org/unisphere/unisphere/group/GroupCUDE2ETest.java
@@ -1,0 +1,933 @@
+package org.unisphere.unisphere.group;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.context.WebApplicationContext;
+import org.unisphere.unisphere.auth.jwt.JwtTokenProvider;
+import org.unisphere.unisphere.group.domain.Group;
+import org.unisphere.unisphere.group.domain.GroupRole;
+import org.unisphere.unisphere.group.dto.request.GroupAvatarUpdateRequestDto;
+import org.unisphere.unisphere.group.dto.request.GroupCreateRequestDto;
+import org.unisphere.unisphere.group.dto.request.GroupHomePageUpdateRequestDto;
+import org.unisphere.unisphere.group.dto.response.GroupHomePageResponseDto;
+import org.unisphere.unisphere.member.domain.Member;
+import org.unisphere.unisphere.utils.E2EMvcTest;
+import org.unisphere.unisphere.utils.JsonMatcher;
+import org.unisphere.unisphere.utils.PersistenceHelper;
+import org.unisphere.unisphere.utils.entity.TestGroup;
+import org.unisphere.unisphere.utils.entity.TestGroupRegistration;
+import org.unisphere.unisphere.utils.entity.TestMember;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class GroupCUDE2ETest extends E2EMvcTest {
+
+	private final String BASE_URL = "/api/v1/groups";
+	private PersistenceHelper persistenceHelper;
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+	private String token;
+
+	@BeforeEach
+	public void setup(WebApplicationContext webApplicationContext) {
+		super.setup(webApplicationContext);
+		persistenceHelper = PersistenceHelper.start(em);
+	}
+
+	@Nested
+	class CreateGroup {
+
+		private final String URL = BASE_URL;
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("이미 존재하는 그룹 이름으로 그룹 생성 요청 시 409 Conflict 응답")
+		public void createGroup_AlreadyExistGroupName_400BadRequest() throws Exception {
+			// given
+			String groupName = "group1";
+			persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.name(groupName)
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name(groupName)
+									.summary("summary")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isConflict());
+		}
+
+		@Test
+		@DisplayName("그룹명이 빈 문자열인 그룹 생성 요청 시, 400 Bad Request 응답")
+		public void createGroup_EmptyGroupName_400BadRequest() throws Exception {
+			// given
+			String emptyGroupName = "";
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name(emptyGroupName)
+									.summary("summary")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("그룹명 길이가 1인 그룹 생성 요청 시, 400 Bad Request 응답")
+		public void createGroup_ShortGroupName_400BadRequest() throws Exception {
+			// given
+			String shortGroupName = "a";
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name(shortGroupName)
+									.summary("summary")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("그룹명 길이가 17인 그룹 생성 요청 시, 400 Bad Request 응답")
+		public void createGroup_LongGroupName_400BadRequest() throws Exception {
+			// given
+			String longGroupName = "12345678901234567";
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name(longGroupName)
+									.summary("summary")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("그룹명에 특수문자가 포함된 그룹 생성 요청 시, 400 Bad Request 응답")
+		public void createGroup_InvalidGroupName_400BadRequest() throws Exception {
+			// given
+			String invalidGroupName = "group!";
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name(invalidGroupName)
+									.summary("summary")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("허용되지 않은 로고 이미지 확장자로 그룹 생성 요청 시, 400 Bad Request 응답")
+		public void createGroup_InvalidLogoImageExtension_400BadRequest() throws Exception {
+			// given
+			String invalidLogoImageExtension = "logo-images/" + UUID.randomUUID() + "/logo.bmp";
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name("group1")
+									.summary("summary")
+									.preSignedLogoImageUrl(invalidLogoImageExtension)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("정상적인 그룹 생성 요청 시, 201 Created 응답")
+		public void createGroup_ValidRequest_201Created() throws Exception {
+			// given
+			String groupName = "group1";
+
+			// when
+			MockHttpServletRequestBuilder request = post(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupCreateRequestDto.builder()
+									.name(groupName)
+									.summary("summary")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+			persistenceHelper.flushAndClear();
+
+			// then
+			resultActions.andExpect(status().isCreated())
+					.andDo(ignore -> {
+						Group queriedGroup = em.createQuery(
+										"select g from group_entity g join fetch g.groupRegistrations gr",
+										Group.class)
+								.getSingleResult();
+						assertThat(queriedGroup.getName()).isEqualTo(groupName);
+						assertThat(queriedGroup.getOwnerMember().getId()).isEqualTo(
+								loginMember.getId());
+						assertThat(queriedGroup.getGroupRegistrations().size()).isEqualTo(1);
+						assertThat(queriedGroup.getGroupRegistrations().get(0).getRole()).isEqualTo(
+								GroupRole.OWNER);
+					});
+		}
+	}
+
+	@Nested
+	class UpdateGroupAvatar {
+
+		private final String URL = BASE_URL;
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 그룹에 대한 그룹 아바타 변경 요청 시, 404 Not Found 응답")
+		public void updateGroupAvatar_NotExistGroup_404NotFound() throws Exception {
+			// given
+			Long notExistGroupId = 1L;
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + notExistGroupId + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name("group1")
+									.preSignedAvatarImageUrl(
+											"avatar-images/" + UUID.randomUUID() + "/avatar.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("존재하는 그룹명으로 그룹 아바타 변경 요청 시, 409 Conflict 응답")
+		public void updateGroupAvatar_AlreadyExistGroupName_409Conflict() throws Exception {
+			// given
+			String groupName = "group1";
+			String preSignedAvatarImageUrl = "avatar-images/" + UUID.randomUUID() + "/avatar.png";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.asDefaultEntity(loginMember)
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+			Group anotherGroup = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.name(groupName)
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, anotherGroup)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name(groupName)
+									.preSignedAvatarImageUrl(preSignedAvatarImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isConflict());
+		}
+
+		@Test
+		@DisplayName("그룹 멤버가 아닌 멤버가 그룹 아바타 변경 요청 시, 403 Forbidden 응답")
+		public void updateGroupAvatar_NotGroupAdmin_403Forbidden() throws Exception {
+			// given
+			String groupName = "group1";
+			String preSignedAvatarImageUrl = "avatar-images/" + UUID.randomUUID() + "/avatar.png";
+			Member anotherMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(anotherMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(anotherMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name(groupName)
+									.preSignedAvatarImageUrl(preSignedAvatarImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("가입 승인된 일반 멤버가 그룹 아바타 변경 요청 시, 403 Forbidden 응답")
+		public void updateGroupAvatar_ApprovedCommonMember_403Forbidden() throws Exception {
+			// given
+			String groupName = "group1";
+			String preSignedAvatarImageUrl = "avatar-images/" + UUID.randomUUID() + "/avatar.png";
+			Member anotherMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(anotherMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(anotherMember, group)
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asApprovedCommonRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name(groupName)
+									.preSignedAvatarImageUrl(preSignedAvatarImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("가입 승인되지 않은 일반 멤버가 그룹 아바타 변경 요청 시, 403 Forbidden 응답")
+		public void updateGroupAvatar_NotApprovedCommonMember_403Forbidden() throws Exception {
+			// given
+			String groupName = "group1";
+			String preSignedAvatarImageUrl = "avatar-images/" + UUID.randomUUID() + "/avatar.png";
+			Member anotherMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(anotherMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(anotherMember, group)
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asNotApprovedCommonRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name(groupName)
+									.preSignedAvatarImageUrl(preSignedAvatarImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("정상적인 그룹 아바타 변경 요청 시, 그룹명은 변경되지 않고 200 OK 응답")
+		public void updateGroupAvatar_ValidRequest_204NoContent() throws Exception {
+			// given
+			String beforeImageUrl = "avatar-images/BEFORE/avatar.png";
+			String afterImageUrl = "avatar-images/AFTER/avatar.png";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.avatarImageUrl(beforeImageUrl)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.preSignedAvatarImageUrl(afterImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+			persistenceHelper.flushAndClear();
+
+			// then
+			resultActions.andExpect(status().isOk())
+					.andDo(ignore -> {
+						Group queriedGroup = em.find(Group.class, group.getId());
+						assertThat(queriedGroup.getAvatarImageUrl()).isEqualTo(afterImageUrl);
+						assertThat(queriedGroup.getName()).isNotNull();
+					});
+		}
+
+		@Test
+		@DisplayName("소유자가 그룹 아바타 변경 요청 시, 204 No Content 응답")
+		public void updateGroupAvatar_Owner_204NoContent() throws Exception {
+			// given
+			String groupName = "group1";
+			String preSignedAvatarImageUrl = "avatar-images/" + UUID.randomUUID() + "/avatar.png";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name(groupName)
+									.preSignedAvatarImageUrl(preSignedAvatarImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+			persistenceHelper.flushAndClear();
+
+			// then
+			resultActions.andExpect(status().isOk())
+					.andDo(ignore -> {
+						Group queriedGroup = em.find(Group.class, group.getId());
+						assertThat(queriedGroup.getAvatarImageUrl()).isNotNull();
+						assertThat(queriedGroup.getName()).isEqualTo(groupName);
+					});
+		}
+
+		@Test
+		@DisplayName("관리자가 그룹 아바타 변경 요청 시, 204 No Content 응답")
+		public void updateGroupAvatar_Admin_204NoContent() throws Exception {
+			// given
+			String groupName = "group1";
+			String preSignedAvatarImageUrl = "avatar-images/" + UUID.randomUUID() + "/avatar.png";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(persistenceHelper.persistAndReturn(
+									TestMember.asDefaultEntity()
+							))
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asAdminRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = patch(URL + "/" + group.getId() + "/avatar")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupAvatarUpdateRequestDto.builder()
+									.name(groupName)
+									.preSignedAvatarImageUrl(preSignedAvatarImageUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+			persistenceHelper.flushAndClear();
+
+			// then
+			resultActions.andExpect(status().isOk())
+					.andDo(ignore -> {
+						Group queriedGroup = em.find(Group.class, group.getId());
+						assertThat(queriedGroup.getAvatarImageUrl()).isNotNull();
+						assertThat(queriedGroup.getName()).isEqualTo(groupName);
+					});
+		}
+	}
+
+	@Nested
+	class PutGroupHomePage {
+
+		private final String URL = BASE_URL;
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 그룹에 대한 그룹 홈페이지 변경 요청 시, 404 Not Found 응답")
+		public void putGroupHomePage_NotExistGroup_404NotFound() throws Exception {
+			// given
+			long notExistGroupId = 9999L;
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + notExistGroupId + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email("example@gmail.com")
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("지원되지 않는 로고 이미지 확장자로 그룹 홈페이지 변경 요청 시, 400 Bad Request 응답")
+		public void putGroupHomePage_InvalidLogoImageExtension_400BadRequest() throws Exception {
+			// given
+			String invalidLogoImageExtension = "logo-images/" + UUID.randomUUID() + "/logo.bmp";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email("example@gmail.com")
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											invalidLogoImageExtension)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("단체 소개가 1025자인 그룹 홈페이지 변경 요청 시, 400 Bad Request 응답")
+		public void putGroupHomePage_LongContent_400BadRequest() throws Exception {
+			// given
+			String longContent = "a" .repeat(1025);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content(longContent)
+									.email("example@gmail.com")
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("단체 이메일 주소가 65자인 그룹 홈페이지 변경 요청 시, 400 Bad Request 응답")
+		public void putGroupHomePage_LongEmail_400BadRequest() throws Exception {
+			// given
+			String longEmail = "a" .repeat(65);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email(longEmail)
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("단체 이메일 형식이 올바르지 않은 그룹 홈페이지 변경 요청 시, 400 Bad Request 응답")
+		public void putGroupHomePage_InvalidEmail_1_400BadRequest() throws Exception {
+			// given
+			String invalidEmail = "example.com";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email(invalidEmail)
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("단체 이메일 형식이 올바르지 않은 그룹 홈페이지 변경 요청 시, 400 Bad Request 응답")
+		public void putGroupHomePage_InvalidEmail_2_400BadRequest() throws Exception {
+			// given
+			String invalidEmail = "example@com";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email(invalidEmail)
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("단체 이메일 형식이 올바르지 않은 그룹 홈페이지 변경 요청 시, 400 Bad Request 응답")
+		public void putGroupHomePage_InvalidEmail_3_400BadRequest() throws Exception {
+			// given
+			String invalidEmail = "example@.com";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email(invalidEmail)
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("그룹 멤버가 아닌 멤버가 그룹 홈페이지 변경 요청 시, 403 Forbidden 응답")
+		public void putGroupHomePage_NotGroupAdmin_403Forbidden() throws Exception {
+			// given
+			Member ownerMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(ownerMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(ownerMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email("example@gmail.com")
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("가입 승인된 일반 멤버가 그룹 홈페이지 변경 요청 시, 403 Forbidden 응답")
+		public void putGroupHomePage_ApprovedCommonMember_403Forbidden() throws Exception {
+			// given
+			Member ownerMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(ownerMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(ownerMember, group)
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asApprovedCommonRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email("example@gmail.com")
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("가입 승인되지 않은 일반 멤버가 그룹 홈페이지 변경 요청 시, 403 Forbidden 응답")
+		public void putGroupHomePage_NotApprovedCommonMember_403Forbidden() throws Exception {
+			// given
+			Member ownerMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(ownerMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(ownerMember, group)
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asNotApprovedCommonRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content("content")
+									.email("example@gmail.com")
+									.groupSiteUrl("https://unisphere.org/group/1")
+									.preSignedLogoImageUrl(
+											"logo-images/" + UUID.randomUUID() + "/logo.png")
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("정상적인 그룹 홈페이지 변경 요청 시, 200 OK 응답")
+		public void putGroupHomePage_ValidRequest_200OK() throws Exception {
+			// given
+			String content = "content";
+			String email = "example@gmail.com";
+			String groupSiteUrl = "https://unisphere.org/group/1";
+			Group group = persistenceHelper.persistAndReturn(
+					TestGroup.builder()
+							.ownerMember(loginMember)
+							.build()
+							.asEntity()
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, group)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = put(
+					URL + "/" + group.getId() + "/home-page")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.content(objectMapper.writeValueAsString(
+							GroupHomePageUpdateRequestDto.builder()
+									.content(content)
+									.email(email)
+									.groupSiteUrl(groupSiteUrl)
+									.build()))
+					.contentType(MediaType.APPLICATION_JSON);
+			ResultActions resultActions = mockMvc.perform(request);
+			persistenceHelper.flushAndClear();
+
+			// then
+			JsonMatcher jsonMatcher = JsonMatcher.create();
+			resultActions.andExpect(status().isOk())
+					.andExpect(jsonMatcher.get(GroupHomePageResponseDto.Fields.content)
+							.isEquals(content))
+					.andExpect(
+							jsonMatcher.get(GroupHomePageResponseDto.Fields.email).isEquals(email))
+					.andExpect(jsonMatcher.get(GroupHomePageResponseDto.Fields.groupSiteUrl)
+							.isEquals(groupSiteUrl));
+		}
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/group/GroupReadE2ETest.java
+++ b/src/test/java/org/unisphere/unisphere/group/GroupReadE2ETest.java
@@ -9,11 +9,16 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.context.WebApplicationContext;
 import org.unisphere.unisphere.auth.jwt.JwtTokenProvider;
+import org.unisphere.unisphere.group.domain.Group;
+import org.unisphere.unisphere.group.domain.GroupRole;
 import org.unisphere.unisphere.group.dto.response.GroupListResponseDto;
+import org.unisphere.unisphere.group.dto.response.GroupMemberListResponseDto;
+import org.unisphere.unisphere.member.domain.Member;
 import org.unisphere.unisphere.utils.E2EMvcTest;
 import org.unisphere.unisphere.utils.JsonMatcher;
 import org.unisphere.unisphere.utils.PersistenceHelper;
 import org.unisphere.unisphere.utils.entity.TestGroup;
+import org.unisphere.unisphere.utils.entity.TestGroupRegistration;
 import org.unisphere.unisphere.utils.entity.TestMember;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -47,13 +52,10 @@ public class GroupReadE2ETest extends E2EMvcTest {
 		}
 
 		@Test
-		@DisplayName("모든 그룹을 조회한다.")
-		public void testGetAllGroups() throws Exception {
+		@DisplayName("전체 그룹 수가 0인 경우, 빈 리스트를 반환한다")
+		public void testGetAllGroups_empty() throws Exception {
 			// given
-			long totalGroupCount = 33;
-			persistenceHelper.persistAndReturn(
-					TestGroup.asDefaultEntities((int) totalGroupCount, loginMember)
-			);
+			long totalGroupCount = 0;
 
 			// when
 			MockHttpServletRequestBuilder request = get(URL)
@@ -66,7 +68,338 @@ public class GroupReadE2ETest extends E2EMvcTest {
 					.andExpect(status().isOk())
 					.andExpect(
 							response.get(GroupListResponseDto.Fields.totalGroupCount)
-									.isEquals(totalGroupCount));
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(0));
+		}
+
+		@Test
+		@DisplayName("전체 그룹 수가 size 보다 큰 경우, size 만큼의 그룹 리스트를 반환한다")
+		public void testGetAllGroups() throws Exception {
+			// given
+			long totalGroupCount = 33;
+			long page = 0;
+			long size = 10;
+			persistenceHelper.persistAndReturn(
+					TestGroup.asDefaultEntities((int) totalGroupCount, loginMember)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(size));
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(size));
+		}
+
+		@Test
+		@DisplayName("전체 그룹 수가 size 보다 작은 경우, 전체 그룹 리스트를 반환한다")
+		public void testGetAllGroups2() throws Exception {
+			// given
+			long totalGroupCount = 5;
+			long page = 0;
+			long size = 10;
+			persistenceHelper.persistAndReturn(
+					TestGroup.asDefaultEntities((int) totalGroupCount, loginMember)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(size));
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(totalGroupCount));
+		}
+	}
+
+	@Nested
+	class GetMyGroups {
+
+		private final String URL = BASE_URL + "/members/me";
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("내 그룹 수가 0인 경우, 빈 리스트를 반환한다")
+		public void testGetMyGroups_empty() throws Exception {
+			// given
+			long totalGroupCount = 0;
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(0));
+		}
+
+		@Test
+		@DisplayName("내가 속한 그룹만 존재")
+		public void testGetMyGroups_onlyMyGroups() throws Exception {
+			// given
+			long totalGroupCount = 33;
+			long page = 0;
+			long size = 10;
+			persistenceHelper.persistAndReturn(
+							TestGroup.asDefaultEntities((int) totalGroupCount, loginMember)
+					)
+					.forEach(group -> persistenceHelper.persistAndReturn(
+							TestGroupRegistration.asOwnerRegistration(loginMember, group)
+					));
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(size));
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(size));
+		}
+
+		@Test
+		@DisplayName("내가 속하지 않은 그롭도 존재")
+		public void testGetMyGroups_myGroupsAndOtherGroups() throws Exception {
+			// given
+			long totalMyGroupCount = 12;
+			long totalOtherGroupCount = 6;
+			long page = 0;
+			long size = 10;
+			persistenceHelper.persistAndReturn(
+					TestGroup.asDefaultEntities((int) totalOtherGroupCount,
+							persistenceHelper.persistAndReturn(TestMember.asDefaultEntity())
+					)
+			);
+			persistenceHelper.persistAndReturn(
+							TestGroup.asDefaultEntities((int) totalMyGroupCount, loginMember)
+					)
+					.forEach(group -> persistenceHelper.persistAndReturn(
+							TestGroupRegistration.asOwnerRegistration(loginMember, group)
+					));
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(size));
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalMyGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(size));
+		}
+	}
+
+	@Nested
+	class GetMemberGroups {
+
+		private final String URL = BASE_URL + "/members";
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("해당 멤버가 존재하지 않는 경우, 404를 응답한다")
+		public void testGetMemberGroups_nonExists() throws Exception {
+			// given
+			long nonExistMemberId = 9999L;
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL + "/" + nonExistMemberId)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("해당 멤버가 속한 그룹이 없는 경우, 빈 리스트를 반환한다")
+		public void testGetMemberGroups_empty() throws Exception {
+			// given
+			Member targetMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			long totalGroupCount = 0;
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL + "/" + targetMember.getId())
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(0));
+		}
+
+		@Test
+		@DisplayName("해당 멤버가 속한 그룹이 존재하는 경우, 해당 멤버가 속한 그룹 리스트를 반환한다")
+		public void testGetMemberGroups() throws Exception {
+			// given
+			Member targetMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			long totalGroupCount = 15;
+			long page = 0;
+			long size = 10;
+			persistenceHelper.persistAndReturn(
+							TestGroup.asDefaultEntities((int) totalGroupCount, targetMember)
+					)
+					.forEach(group -> persistenceHelper.persistAndReturn(
+							TestGroupRegistration.asOwnerRegistration(targetMember, group)
+					));
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL + "/" + targetMember.getId())
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(size));
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount))
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.groups)
+									.get("length()").isEquals(size));
+		}
+	}
+
+	@Nested
+	class GetGroupMembers {
+
+		private final String URL = BASE_URL;
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("해당 그룹이 존재하지 않는 경우, 404를 응답한다")
+		public void testGetGroupMembers_nonExists() throws Exception {
+			// given
+			long nonExistGroupId = 9999L;
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL + "/" + nonExistGroupId + "/members")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			resultActions.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("해당 그룹에 소유자만 속한 경우, 소유자만 반환한다")
+		public void testGetGroupMembers_onlyOwner() throws Exception {
+			// given
+			long totalMemberCount = 1;
+			Group targetGroup = persistenceHelper.persistAndReturn(
+					TestGroup.asDefaultEntity(loginMember)
+			);
+			persistenceHelper.persistAndReturn(
+					TestGroupRegistration.asOwnerRegistration(loginMember, targetGroup)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = get(
+					URL + "/" + targetGroup.getId() + "/members")
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupMemberListResponseDto.Fields.totalMemberCount)
+									.isEquals(totalMemberCount))
+					.andExpect(
+							response.get(GroupMemberListResponseDto.Fields.groupMembers)
+									.get("length()").isEquals(totalMemberCount)
+					)
+					.andExpectAll(
+							response.get(
+											GroupMemberListResponseDto.Fields.groupMembers + "[0].memberId")
+									.isEquals(loginMember.getId()),
+							response.get(
+											GroupMemberListResponseDto.Fields.groupMembers + "[0].role")
+									.isEquals(GroupRole.OWNER.name())
+					);
 		}
 	}
 }

--- a/src/test/java/org/unisphere/unisphere/group/GroupReadE2ETest.java
+++ b/src/test/java/org/unisphere/unisphere/group/GroupReadE2ETest.java
@@ -1,0 +1,72 @@
+package org.unisphere.unisphere.group;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.context.WebApplicationContext;
+import org.unisphere.unisphere.auth.jwt.JwtTokenProvider;
+import org.unisphere.unisphere.group.dto.response.GroupListResponseDto;
+import org.unisphere.unisphere.utils.E2EMvcTest;
+import org.unisphere.unisphere.utils.JsonMatcher;
+import org.unisphere.unisphere.utils.PersistenceHelper;
+import org.unisphere.unisphere.utils.entity.TestGroup;
+import org.unisphere.unisphere.utils.entity.TestMember;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class GroupReadE2ETest extends E2EMvcTest {
+
+	private final String BASE_URL = "/api/v1/groups";
+	private PersistenceHelper persistenceHelper;
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+	private String token;
+
+	@BeforeEach
+	public void setup(WebApplicationContext webApplicationContext) {
+		super.setup(webApplicationContext);
+		persistenceHelper = PersistenceHelper.start(em);
+	}
+
+	@Nested
+	class GetAllGroups {
+
+		private final String URL = BASE_URL + "/all";
+
+		@BeforeEach
+		public void setup() {
+			loginMember = persistenceHelper.persistAndReturn(
+					TestMember.asDefaultEntity()
+			);
+			token = jwtTokenProvider.createCommonAccessToken(loginMember.getId()).getTokenValue();
+		}
+
+		@Test
+		@DisplayName("모든 그룹을 조회한다.")
+		public void testGetAllGroups() throws Exception {
+			// given
+			long totalGroupCount = 33;
+			persistenceHelper.persistAndReturn(
+					TestGroup.asDefaultEntities((int) totalGroupCount, loginMember)
+			);
+
+			// when
+			MockHttpServletRequestBuilder request = get(URL)
+					.header(AUTHORIZATION_VALUE, BEARER_VALUE + token);
+			ResultActions resultActions = mockMvc.perform(request);
+
+			// then
+			JsonMatcher response = JsonMatcher.create();
+			resultActions
+					.andExpect(status().isOk())
+					.andExpect(
+							response.get(GroupListResponseDto.Fields.totalGroupCount)
+									.isEquals(totalGroupCount));
+		}
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/E2EMvcTest.java
+++ b/src/test/java/org/unisphere/unisphere/utils/E2EMvcTest.java
@@ -1,0 +1,44 @@
+package org.unisphere.unisphere.utils;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.unisphere.unisphere.member.domain.Member;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Import(ExternalDependenciesIgnore.class)
+@Transactional
+public abstract class E2EMvcTest {
+
+	@PersistenceContext
+	protected EntityManager em;
+	protected MockMvc mockMvc;
+	protected final String BEARER_VALUE = "Bearer ";
+	protected final String AUTHORIZATION_VALUE = "Authorization";
+	protected Member loginMember;
+
+	@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+	@Autowired protected ObjectMapper objectMapper;
+
+	@BeforeEach
+	protected void setup(WebApplicationContext webApplicationContext) {
+		mockMvc = MockMvcBuilders
+				.webAppContextSetup(webApplicationContext)
+				.addFilters(new CharacterEncodingFilter("UTF-8", true))
+				.apply(springSecurity())
+				.build();
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/ExternalDependenciesIgnore.java
+++ b/src/test/java/org/unisphere/unisphere/utils/ExternalDependenciesIgnore.java
@@ -1,0 +1,33 @@
+package org.unisphere.unisphere.utils;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.unisphere.unisphere.image.domain.ObjectStorageManager;
+
+@TestConfiguration
+public class ExternalDependenciesIgnore {
+
+	@Bean
+	public ObjectStorageManager objectStorageManager() {
+		return new ObjectStorageManager() {
+			@Override
+			public void delete(String key) {
+			}
+
+			@Override
+			public String getPreSignedUrl(String key) {
+				return null;
+			}
+
+			@Override
+			public String getObjectUrl(String key) {
+				return null;
+			}
+
+			@Override
+			public boolean doesObjectExist(String key) {
+				return true;
+			}
+		};
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/JsonMatcher.java
+++ b/src/test/java/org/unisphere/unisphere/utils/JsonMatcher.java
@@ -1,0 +1,59 @@
+package org.unisphere.unisphere.utils;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.Map;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.result.JsonPathResultMatchers;
+
+public class JsonMatcher {
+
+	private final static String JSON_ROOT = "$";
+	private final StringBuilder sb = new StringBuilder();
+
+	private JsonMatcher(String defaultPath) {
+		this.sb.append(defaultPath);
+	}
+
+	private void clear() {
+		sb.delete(1, sb.length());
+	}
+
+	public static JsonMatcher create() {
+		return new JsonMatcher(JSON_ROOT);
+	}
+
+	public JsonMatcher clone() {
+		return new JsonMatcher(sb.toString());
+	}
+
+	public JsonMatcher get(String property) {
+		sb.append(".").append(property);
+		return this;
+	}
+
+	public JsonMatcher at(int index) {
+		sb.append("[").append(index).append("]");
+		return this;
+	}
+
+	public JsonPathResultMatchers is() {
+		JsonPathResultMatchers jsonPathResultMatchers = jsonPath(sb.toString());
+		clear();
+		return jsonPathResultMatchers;
+	}
+
+	public ResultMatcher isEquals(Object expected) {
+		String result = sb.toString();
+		clear();
+		return jsonPath(result).value(expected);
+	}
+
+	public ResultMatcher[] isEquals(Map<String, Object> expected) {
+		ResultMatcher[] matchers = expected.entrySet().stream().map(entry ->
+						this.clone().get(entry.getKey()).isEquals(entry.getValue()))
+				.toArray(ResultMatcher[]::new);
+		clear();
+		return matchers;
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/PersistenceHelper.java
+++ b/src/test/java/org/unisphere/unisphere/utils/PersistenceHelper.java
@@ -1,0 +1,67 @@
+package org.unisphere.unisphere.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+
+public class PersistenceHelper {
+
+	private final EntityManager em;
+
+	private PersistenceHelper(EntityManager em) {
+		this.em = em;
+	}
+
+	public static PersistenceHelper start(EntityManager em) {
+		return new PersistenceHelper(em);
+	}
+
+	@SafeVarargs
+	public final <E> PersistenceHelper persist(E... entities) {
+		for (E entity : entities) {
+			this.em.persist(entity);
+		}
+		return this;
+	}
+
+	public PersistenceHelper and() {
+		return this;
+	}
+
+	public PersistenceHelper flush() {
+		this.em.flush();
+		return this;
+	}
+
+	public PersistenceHelper clear() {
+		this.em.clear();
+		return this;
+	}
+
+	public void flushAndClear() {
+		this.flush().clear();
+	}
+
+	public <E> List<E> persistAndReturn(Collection<E> entities) {
+		for (Object entity : entities) {
+			this.em.persist(entity);
+		}
+		return new ArrayList<>(entities);
+	}
+
+	@SafeVarargs
+	public final <E> List<E> persistAndReturn(E... entities) {
+		for (Object entity : entities) {
+			this.em.persist(entity);
+		}
+		return Arrays.stream(entities).collect(Collectors.toList());
+	}
+
+	public <E> E persistAndReturn(E entity) {
+		this.em.persist(entity);
+		return entity;
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/entity/TestEntity.java
+++ b/src/test/java/org/unisphere/unisphere/utils/entity/TestEntity.java
@@ -1,0 +1,8 @@
+package org.unisphere.unisphere.utils.entity;
+
+public interface TestEntity<E, ID> {
+
+	E asEntity();
+
+	E asMockEntity(ID id);
+}

--- a/src/test/java/org/unisphere/unisphere/utils/entity/TestGroup.java
+++ b/src/test/java/org/unisphere/unisphere/utils/entity/TestGroup.java
@@ -1,0 +1,76 @@
+package org.unisphere.unisphere.utils.entity;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.Builder;
+import org.unisphere.unisphere.group.domain.Group;
+import org.unisphere.unisphere.member.domain.Member;
+
+@Builder
+public class TestGroup implements TestEntity<Group, Long> {
+
+	@Builder.Default
+	private String DEFAULT_SUMMARY_VALUE = "summary";
+	@Builder.Default
+	private String DEFAULT_CONTENT_VALUE = "content";
+	@Builder.Default
+	private String DEFAULT_GROUP_SITE_URL_VALUE = "https://example.com";
+	@Builder.Default
+	private String DEFAULT_EMAIL_VALUE = "example@gmail.com";
+	@Builder.Default
+	private LocalDateTime DEFAULT_CREATED_AT_VALUE = LocalDateTime.of(LocalDate.EPOCH,
+			LocalTime.MIDNIGHT);
+	private Member ownerMember;
+	private String avatarImageUrl;
+	private String logoImageUrl;
+
+	public static Group asDefaultEntity(Member ownerMember) {
+		return TestGroup.builder()
+				.logoImageUrl("logo-images/" + UUID.randomUUID() + "/logo.png")
+				.avatarImageUrl("avatar-images/" + UUID.randomUUID() + "/avatar.png")
+				.ownerMember(ownerMember)
+				.build().asEntity();
+	}
+
+	public static List<Group> asDefaultEntities(int count, Member ownerMember) {
+		return IntStream.range(0, count)
+				.mapToObj(i -> asDefaultEntity(ownerMember))
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	public Group asEntity() {
+		return Group.createGroup(
+				DEFAULT_CREATED_AT_VALUE,
+				ownerMember,
+				UUID.randomUUID().toString(),
+				DEFAULT_SUMMARY_VALUE,
+				"logo-images/" + UUID.randomUUID() + "/logo.png"
+		);
+	}
+
+	@Override
+	public Group asMockEntity(Long id) {
+		Group group = mock(Group.class);
+		lenient().when(group.getId()).thenReturn(id);
+		lenient().when(group.getName()).thenReturn(UUID.randomUUID().toString());
+		lenient().when(group.getSummary()).thenReturn(DEFAULT_SUMMARY_VALUE);
+		lenient().when(group.getContent()).thenReturn(DEFAULT_CONTENT_VALUE);
+		lenient().when(group.getGroupSiteUrl()).thenReturn(DEFAULT_GROUP_SITE_URL_VALUE);
+		lenient().when(group.getCreatedAt()).thenReturn(DEFAULT_CREATED_AT_VALUE);
+		lenient().when(group.getAvatarImageUrl())
+				.thenReturn("avatar-images/" + UUID.randomUUID() + "/avatar.png");
+		lenient().when(group.getLogoImageUrl())
+				.thenReturn("logo-images/" + UUID.randomUUID() + "/logo.png");
+		lenient().when(group.getApprovedAt()).thenReturn(null);
+		return group;
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/entity/TestGroup.java
+++ b/src/test/java/org/unisphere/unisphere/utils/entity/TestGroup.java
@@ -31,6 +31,7 @@ public class TestGroup implements TestEntity<Group, Long> {
 	private Member ownerMember;
 	private String avatarImageUrl;
 	private String logoImageUrl;
+	private String name;
 
 	public static Group asDefaultEntity(Member ownerMember) {
 		return TestGroup.builder()
@@ -51,9 +52,10 @@ public class TestGroup implements TestEntity<Group, Long> {
 		return Group.createGroup(
 				DEFAULT_CREATED_AT_VALUE,
 				ownerMember,
-				UUID.randomUUID().toString(),
+				name != null ? name : UUID.randomUUID().toString(),
 				DEFAULT_SUMMARY_VALUE,
-				"logo-images/" + UUID.randomUUID() + "/logo.png"
+				logoImageUrl != null ? logoImageUrl
+						: "logo-images/" + UUID.randomUUID() + "/logo.png"
 		);
 	}
 

--- a/src/test/java/org/unisphere/unisphere/utils/entity/TestGroupRegistration.java
+++ b/src/test/java/org/unisphere/unisphere/utils/entity/TestGroupRegistration.java
@@ -41,10 +41,19 @@ public class TestGroupRegistration implements TestEntity<GroupRegistration, Long
 				.build().asEntity();
 	}
 
-	public static GroupRegistration asCommonRegistration(Member member, Group group) {
+	public static GroupRegistration asNotApprovedCommonRegistration(Member member, Group group) {
 		return TestGroupRegistration.builder()
 				.role(GroupRole.COMMON)
 				.registeredAt(null)
+				.member(member)
+				.group(group)
+				.build().asEntity();
+	}
+
+	public static GroupRegistration asApprovedCommonRegistration(Member member, Group group) {
+		return TestGroupRegistration.builder()
+				.role(GroupRole.COMMON)
+				.registeredAt(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIDNIGHT))
 				.member(member)
 				.group(group)
 				.build().asEntity();
@@ -60,16 +69,17 @@ public class TestGroupRegistration implements TestEntity<GroupRegistration, Long
 	public static List<GroupRegistration> asCommonRegistrations(int count, Member member,
 			Group group) {
 		return IntStream.range(0, count)
-				.mapToObj(i -> asCommonRegistration(member, group))
+				.mapToObj(i -> asNotApprovedCommonRegistration(member, group))
 				.collect(Collectors.toList());
 	}
 
 	@Override
 	public GroupRegistration asEntity() {
-		return GroupRegistration.createOwnerRegistration(
-				registeredAt,
+		return GroupRegistration.of(
 				member,
-				group
+				group,
+				role,
+				registeredAt
 		);
 	}
 

--- a/src/test/java/org/unisphere/unisphere/utils/entity/TestGroupRegistration.java
+++ b/src/test/java/org/unisphere/unisphere/utils/entity/TestGroupRegistration.java
@@ -1,0 +1,85 @@
+package org.unisphere.unisphere.utils.entity;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.Builder;
+import org.unisphere.unisphere.group.domain.Group;
+import org.unisphere.unisphere.group.domain.GroupRegistration;
+import org.unisphere.unisphere.group.domain.GroupRole;
+import org.unisphere.unisphere.member.domain.Member;
+
+@Builder
+public class TestGroupRegistration implements TestEntity<GroupRegistration, Long> {
+
+	private GroupRole role;
+	private LocalDateTime registeredAt;
+	private Member member;
+	private Group group;
+
+	public static GroupRegistration asOwnerRegistration(Member member, Group group) {
+		return TestGroupRegistration.builder()
+				.role(GroupRole.OWNER)
+				.registeredAt(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIDNIGHT))
+				.member(member)
+				.group(group)
+				.build().asEntity();
+	}
+
+	public static GroupRegistration asAdminRegistration(Member member, Group group) {
+		return TestGroupRegistration.builder()
+				.role(GroupRole.ADMIN)
+				.registeredAt(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIDNIGHT))
+				.member(member)
+				.group(group)
+				.build().asEntity();
+	}
+
+	public static GroupRegistration asCommonRegistration(Member member, Group group) {
+		return TestGroupRegistration.builder()
+				.role(GroupRole.COMMON)
+				.registeredAt(null)
+				.member(member)
+				.group(group)
+				.build().asEntity();
+	}
+
+	public static List<GroupRegistration> asAdminRegistrations(int count, Member member,
+			Group group) {
+		return IntStream.range(0, count)
+				.mapToObj(i -> asAdminRegistration(member, group))
+				.collect(Collectors.toList());
+	}
+
+	public static List<GroupRegistration> asCommonRegistrations(int count, Member member,
+			Group group) {
+		return IntStream.range(0, count)
+				.mapToObj(i -> asCommonRegistration(member, group))
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	public GroupRegistration asEntity() {
+		return GroupRegistration.createOwnerRegistration(
+				registeredAt,
+				member,
+				group
+		);
+	}
+
+	@Override
+	public GroupRegistration asMockEntity(Long id) {
+		GroupRegistration groupRegistration = mock(GroupRegistration.class);
+		lenient().when(groupRegistration.getRole()).thenReturn(role);
+		lenient().when(groupRegistration.getRegisteredAt()).thenReturn(registeredAt);
+		lenient().when(groupRegistration.getMember()).thenReturn(member);
+		lenient().when(groupRegistration.getGroup()).thenReturn(group);
+		return groupRegistration;
+	}
+}

--- a/src/test/java/org/unisphere/unisphere/utils/entity/TestMember.java
+++ b/src/test/java/org/unisphere/unisphere/utils/entity/TestMember.java
@@ -1,0 +1,55 @@
+package org.unisphere.unisphere.utils.entity;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.Builder;
+import org.unisphere.unisphere.auth.domain.MemberRole;
+import org.unisphere.unisphere.member.domain.Member;
+
+@Builder
+public class TestMember implements TestEntity<Member, Long> {
+
+	@Builder.Default
+	private MemberRole DEFAULT_ROLE = MemberRole.MEMBER;
+	@Builder.Default
+	private LocalDateTime DEFAULT_CREATED_AT_VALUE = LocalDateTime.of(LocalDate.EPOCH,
+			LocalTime.MIDNIGHT);
+	@Builder.Default
+	private String DEFAULT_DELETED_AT_VALUE = null;
+	private String email;
+	private String nickname;
+	private String avatarImageUrl;
+
+	public static Member asDefaultEntity() {
+		return TestMember.builder()
+				.email(UUID.randomUUID() + "@gmail.com")
+				.nickname(UUID.randomUUID().toString())
+				.avatarImageUrl("avatar-images/" + UUID.randomUUID() + "/avatar.png")
+				.build().asEntity();
+	}
+
+	@Override
+	public Member asEntity() {
+		return Member.of(
+				UUID.randomUUID() + "@gmail.com",
+				UUID.randomUUID().toString(),
+				DEFAULT_CREATED_AT_VALUE,
+				DEFAULT_ROLE
+		);
+	}
+
+	@Override
+	public Member asMockEntity(Long id) {
+		Member member = mock(Member.class);
+		lenient().when(member.getId()).thenReturn(id);
+		lenient().when(member.getEmail()).thenReturn(email);
+		lenient().when(member.getNickname()).thenReturn(nickname);
+		lenient().when(member.getAvatarImageUrl()).thenReturn(avatarImageUrl);
+		return member;
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    activate:
+      on-profile: test
   datasource:
     url: jdbc:h2:mem:testdb
     username: sa
@@ -10,9 +13,10 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     properties:
       hibernate:
-        show_sql: false
+        show_sql: true
         format_sql: true
         globally_quoted_identifiers: true
+        globally_quoted_identifiers_skip_column_definitions: true
   security:
     oauth2:
       client:


### PR DESCRIPTION
다음과 같이 그룹 관련 API를 구현했습니다.
논의한대로 유니스피어 관리자와 관련된 API는 구현하지 않았고, 일반 유저가 사용할 수 있는 API들만 구현했습니다.

- [x] GET /api/v1/groups/all: 전체 단체 목록 조회
- [x] GET /api/v1/groups/members/me: 내가 속한 단체 목록 조회
- [x] GET /api/v1/groups/members/{memberId}: 특정 회원이 속한 단체 목록 조회
- [x] GET /api/v1/groups/{groupId}/avatar: 특정 단체 아바타 조회
- [x] PATCH /api/v1/groups/{groupId}/avatar: 특정 단체 아바타 수정 (단체 관리자만 가능)
- [x] GET /api/v1/groups/{groupId}/home-page: 특정 단체 홈피 정보 조회
- [x] PUT /api/v1/groups/{groupId}/home-page: 특정 단체 홈피 정보 수정 (단체 관리자만 가능)
- [x] GET /api/v1/groups/{groupId}/members: 특정 단체에 속한 회원 목록 조회
- [x] POST /api/v1/groups: 단체 생성 요청 (유니스피어 관리자의 승인이 필요하고, approvedAt 필드가 null인지 여부로 판단)
- [x] POST /api/v1/groups/{groupId}/register: 단체 가입 요청 (단체 관리자의 승인이 필요하며, registeredAt 필드가 null인지 여부로 판단)
- [x] PATCH /api/v1/groups/{groupId}/members/{memberId}/register/approve: 단체 가입 승인 (단체 관리자만 승인 가능)
- [x] PATCH /api/v1/groups/{groupId}/members/{memberId}/admin/appoint: 단체 관리자로 임명 (단체 소유자만 호출 가능)
- [x] PATCH /api/v1/groups/{groupId}/members/{memberId}/owner/appoint: 단체 소유자 위임 (단체 소유자만 호출 가능, 임명 후 본인은 단체 관리자로 변경)
- [x] DELETE /api/v1/groups/{groupId}: 단체 삭제 (단체  소유자만 호출 가능)
- [x] DELETE /api/v1/groups/{groupId}/unregister: 단체 탈퇴 (단체 소유자가 요청하면 소유자를 다른 단체 관리자나 단체 회원에게 위임하고, 혼자 남아있는 상태에서 요청한 경우에는 단체가 삭제)
- [x] DELETE /api/v1/groups/{groupId}/members/{memberId}/kick: 단체에서 특정 회원 추방 (단체 관리자 이상의 등급만 호출할 수 있으며 자신보다 등급이 높거나 같은 대상에게는 호출할 수 없음.)

미리 논의하지는 않았지만 구현하면서 필요하다고 생각되는 **단체 삭제, 관리자 임명, 소유자 위임** API를 추가로 구현했습니다.